### PR TITLE
Fix cmdline long description

### DIFF
--- a/cmd/attach-volume.go
+++ b/cmd/attach-volume.go
@@ -1,32 +1,33 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var mountPoint string
 
 var attachCmd = &cobra.Command{
-	Use:   "attach-volume",
+	Use:     "attach-volume",
 	Aliases: []string{"attach"},
-	Short: "Attach a volume to a stopped instance",
+	Short:   "Attach a volume to a stopped instance",
 	Long: `Attaches a volume to a stopped instance at a specified mount point.
-	You specify the volume by name or id.
+You specify the volume by name or id.
 
-	The volume must be attached to an available mount point on the instance.
-	Mount points are image-specific, and are determined when the image is compiled.
+The volume must be attached to an available mount point on the instance.
+Mount points are image-specific, and are determined when the image is compiled.
 
-	For a list of mount points on the image for this instance, run unik images, or
-	unik describe image
+For a list of mount points on the image for this instance, run unik images, or
+unik describe image
 
-	If the specified mount point is occupied by another volume, the command will result
-	in an error
-	`,
-	
+If the specified mount point is occupied by another volume, the command will result
+in an error
+`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,13 +1,15 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
-	"os"
-	unikos "github.com/emc-advanced-dev/unik/pkg/os"
 	"io/ioutil"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
+	unikos "github.com/emc-advanced-dev/unik/pkg/os"
 	unikutil "github.com/emc-advanced-dev/unik/pkg/util"
 )
 
@@ -20,34 +22,34 @@ var buildCmd = &cobra.Command{
 	Short: "Build a unikernel image from source code files",
 	Long: `Compiles source files into a runnable unikernel image.
 
-	Images must be compiled for a specific provider, specified with the --provider flag
-	To see a list of available providers, run 'unik providers'
+Images must be compiled for a specific provider, specified with the --provider flag
+To see a list of available providers, run 'unik providers'
 
-	A unikernel compiler that is compatible with the provider must be specified with the --compiler flag
-	To see a list of available compilers, run 'unik compilers'
+A unikernel compiler that is compatible with the provider must be specified with the --compiler flag
+To see a list of available compilers, run 'unik compilers'
 
-	If you wish to attach volumes to instances of an image, the image must be compiled in advance
-	with a list of the expected mount points. e.g. for an application that reads from a '/data' folder,
-	the unikernel should be compiled with the flag -mount /data
+If you wish to attach volumes to instances of an image, the image must be compiled in advance
+with a list of the expected mount points. e.g. for an application that reads from a '/data' folder,
+the unikernel should be compiled with the flag -mount /data
 
-	Runtime arguments to be passed to your unikernel must also be specified at compile time.
-	You can specify arguments as a single string passed to the --args flag
+Runtime arguments to be passed to your unikernel must also be specified at compile time.
+You can specify arguments as a single string passed to the --args flag
 
-	Image names must be unique. If an image exists with the same name, you can force overwriting with the
-	--force flag
+Image names must be unique. If an image exists with the same name, you can force overwriting with the
+--force flag
 
-	Example usage:
-		unik build --name myUnikernel --path ./myApp/src --compiler rump-go-xen --provider aws --mountpoint /foo --mountpoint /bar --args '-myParameter MYVALUE' --force
+Example usage:
+	unik build --name myUnikernel --path ./myApp/src --compiler rump-go-xen --provider aws --mountpoint /foo --mountpoint /bar --args '-myParameter MYVALUE' --force
 
-		# will create a unikernel named myUnikernel using the sources found in ./myApp/src,
-		# compiled using rumprun for the xen hypervisor, targeting AWS infrastructure,
-		# expecting a volume to be mounted at /foo at runtime,
-		# expecting another volume to be mounted at /bar at runtime,
-		# passing '-myParameter MYVALUE' as arguments to the application when it is run,
-		# and deleting any previous existing instances and image for the name myUnikernel before compiling
+	# will create a unikernel named myUnikernel using the sources found in ./myApp/src,
+	# compiled using rumprun for the xen hypervisor, targeting AWS infrastructure,
+	# expecting a volume to be mounted at /foo at runtime,
+	# expecting another volume to be mounted at /bar at runtime,
+	# passing '-myParameter MYVALUE' as arguments to the application when it is run,
+	# and deleting any previous existing instances and image for the name myUnikernel before compiling
 
-	Another example (using only the required parameters):
-		unik build --name anotherUnikernel --path ./anotherApp/src --compiler rump-go-vmware --provider vsphere
+Another example (using only the required parameters):
+	unik build --name anotherUnikernel --path ./anotherApp/src --compiler rump-go-vmware --provider vsphere
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
@@ -70,14 +72,14 @@ var buildCmd = &cobra.Command{
 				host = clientConfig.Host
 			}
 			logrus.WithFields(logrus.Fields{
-				"name": name,
-				"path": path,
-				"compiler": compiler,
-				"provider": provider ,
-				"args": args,
+				"name":        name,
+				"path":        path,
+				"compiler":    compiler,
+				"provider":    provider,
+				"args":        args,
 				"mountPoints": mountPoints,
-				"force": force,
-				"host": host,
+				"force":       force,
+				"host":        host,
 			}).Infof("running unik build")
 			sourceTar, err := ioutil.TempFile(unikutil.UnikTmpDir(), "")
 			if err != nil {

--- a/cmd/compilers.go
+++ b/cmd/compilers.go
@@ -15,18 +15,20 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
 	"fmt"
-	"strings"
 	"os"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var compilersCmd = &cobra.Command{
 	Use:   "compilers",
 	Short: "List available unikernel compilers",
-	Long: `Returns a list of compilers available to the targeted unik backend.`,
+	Long:  `Returns a list of compilers available to the targeted unik backend.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/create-volume.go
+++ b/cmd/create-volume.go
@@ -1,13 +1,15 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
-	"os"
-	unikos "github.com/emc-advanced-dev/unik/pkg/os"
 	"io/ioutil"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
+	unikos "github.com/emc-advanced-dev/unik/pkg/os"
 	unikutil "github.com/emc-advanced-dev/unik/pkg/util"
 )
 
@@ -18,44 +20,44 @@ var cvCmd = &cobra.Command{
 	Use:   "create-volume",
 	Short: "Create a unik-managed data volume",
 	Long: `Create a data volume which can be attached to and detached from
-	unik-managed instances.
+unik-managed instances.
 
-	Volumes can be created from a directory, which will copy the contents
-	of the directory onto the voume. Empty volume can also be created.
+Volumes can be created from a directory, which will copy the contents
+of the directory onto the voume. Empty volume can also be created.
 
-	Volumes will persist after instances are deleted, allowing application data
-	to be persisted beyond the lifecycle of individual instances.
+Volumes will persist after instances are deleted, allowing application data
+to be persisted beyond the lifecycle of individual instances.
 
-	If specifying a data folder (with --data), specifying a size for the volume is
-	not necessary. UniK will automatically size the volume to fit the data provided.
-	A larger volume can be requested with the --size flag.
+If specifying a data folder (with --data), specifying a size for the volume is
+not necessary. UniK will automatically size the volume to fit the data provided.
+A larger volume can be requested with the --size flag.
 
-	If no data directory is provided, --size is a required parameter to specify the
-	desired size for the empty volume to be createad.
+If no data directory is provided, --size is a required parameter to specify the
+desired size for the empty volume to be createad.
 
-	Volumes are created for a specific provider, specified with the --provider flag.
-	Volumes can only be attached to instances of the same provider type.
-	To see a list of available providers, run 'unik providers'
+Volumes are created for a specific provider, specified with the --provider flag.
+Volumes can only be attached to instances of the same provider type.
+To see a list of available providers, run 'unik providers'
 
-	Volume names must be unique. If a volume exists with the same name, you will be
-	required to remove the volume with 'unik delete-volume' before the new volume
-	can be created.
+Volume names must be unique. If a volume exists with the same name, you will be
+required to remove the volume with 'unik delete-volume' before the new volume
+can be created.
 
-	--size parameter uses MB
+--size parameter uses MB
 
-	Example usage:
-		unik create-volume --name myVolume --data ./myApp/data --provider aws
+Example usage:
+	unik create-volume --name myVolume --data ./myApp/data --provider aws
 
-		# will create an EBS-backed AWS volume named myVolume using the data found in ./myApp/src,
-		# the size will be either 1GB (the default minimum size on AWS) or greater, if the size of the
-		volume is greater
+	# will create an EBS-backed AWS volume named myVolume using the data found in ./myApp/src,
+	# the size will be either 1GB (the default minimum size on AWS) or greater, if the size of the
+	volume is greater
 
 
-	Another example (empty volume):
-		unik create-volume -name anotherVolume --size 500 -provider vsphere
+Another example (empty volume):
+	unik create-volume -name anotherVolume --size 500 -provider vsphere
 
-		# will create a 500mb sparse vmdk file and upload it to the vsphere datastore,
-		where it can be attached to a vsphere instance
+	# will create a 500mb sparse vmdk file and upload it to the vsphere datastore,
+	where it can be attached to a vsphere instance
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
@@ -75,11 +77,11 @@ var cvCmd = &cobra.Command{
 				host = clientConfig.Host
 			}
 			logrus.WithFields(logrus.Fields{
-				"name": name,
-				"data": data,
-				"size": size,
+				"name":     name,
+				"data":     data,
+				"size":     size,
 				"provider": provider,
-				"host": host,
+				"host":     host,
 			}).Infof("creating volume")
 			if data != "" {
 				dataTar, err := ioutil.TempFile(unikutil.UnikTmpDir(), "")

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -1,16 +1,18 @@
 package cmd
 
 import (
-	unikutil "github.com/emc-advanced-dev/unik/pkg/util"
-	"github.com/spf13/cobra"
-	"os"
-	"github.com/Sirupsen/logrus"
-	"io/ioutil"
-	"github.com/emc-advanced-dev/unik/pkg/config"
-	"gopkg.in/yaml.v2"
-	"github.com/emc-advanced-dev/unik/pkg/daemon"
 	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/config"
+	"github.com/emc-advanced-dev/unik/pkg/daemon"
+	unikutil "github.com/emc-advanced-dev/unik/pkg/util"
 )
 
 var daemonConfigFile, logFile string
@@ -20,22 +22,22 @@ var daemonCmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "Runs the unik backend (daemon)",
 	Long: `Run this command to start the unik daemon process.
-	This should normally be left running as a long-running background process.
-	The daemon requires that docker is installed and running on the your system.
-	Necessary docker containers must be built for the daemon to work properly;
-	Run 'make' in the unik root directory to build all necessary containers.
+This should normally be left running as a long-running background process.
+The daemon requires that docker is installed and running on the your system.
+Necessary docker containers must be built for the daemon to work properly;
+Run 'make' in the unik root directory to build all necessary containers.
 
-	Daemon also requires a configuration file with credentials and configuration info
-	for desired providers.
+Daemon also requires a configuration file with credentials and configuration info
+for desired providers.
 
-	Example usage:
-		unik daemon --f ./my-config.yaml --port 12345 --debug --trace --logfile logs.txt
+Example usage:
+	unik daemon --f ./my-config.yaml --port 12345 --debug --trace --logfile logs.txt
 
-		 # will start the daemon using config file at my-config.yaml
-		 # running on port 12345
-		 # debug mode activated
-		 # trace mode activated
-		 # outputting logs to logs.txt
+	 # will start the daemon using config file at my-config.yaml
+	 # running on port 12345
+	 # debug mode activated
+	 # trace mode activated
+	 # outputting logs to logs.txt
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
@@ -78,17 +80,17 @@ func init() {
 	daemonCmd.Flags().StringVar(&logFile, "logfile", "", "<string, optional> output logs to file (in addition to stdout)")
 }
 
-
 var daemonConfig config.DaemonConfig
+
 func readDaemonConfig() error {
 	data, err := ioutil.ReadFile(daemonConfigFile)
 	if err != nil {
-		logrus.WithError(err).Errorf("failed to read daemon configuration file at "+ daemonConfigFile +`\n
+		logrus.WithError(err).Errorf("failed to read daemon configuration file at " + daemonConfigFile + `\n
 		See documentation at http://github.com/emc-advanced-dev/unik for creating daemon config.'`)
 		return err
 	}
 	if err := yaml.Unmarshal(data, &daemonConfig); err != nil {
-		logrus.WithError(err).Errorf("failed to parse daemon configuration yaml at "+ daemonConfigFile +`\n
+		logrus.WithError(err).Errorf("failed to parse daemon configuration yaml at " + daemonConfigFile + `\n
 		Please ensure config file contains valid yaml.'`)
 		return err
 	}

--- a/cmd/delete-image.go
+++ b/cmd/delete-image.go
@@ -1,20 +1,21 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var rmiCmd = &cobra.Command{
-	Use:   "delete-image",
+	Use:     "delete-image",
 	Aliases: []string{"rmi"},
-	Short: "Delete a unikernel image",
+	Short:   "Delete a unikernel image",
 	Long: `Deletes an image.
-	You may specify the image by name or id.`,
-	
+You may specify the image by name or id.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/delete-instance.go
+++ b/cmd/delete-instance.go
@@ -1,19 +1,21 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var rmCmd = &cobra.Command{
-	Use:   "delete-instance",
+	Use:     "delete-instance",
 	Aliases: []string{"rm"},
-	Short: "Delete a unikernel instance",
+	Short:   "Delete a unikernel instance",
 	Long: `Deletes an instance.
-	You may specify the instance by name or id.`,
+You may specify the instance by name or id.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/delete-volume.go
+++ b/cmd/delete-volume.go
@@ -1,22 +1,23 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
-var volumeName string 
+var volumeName string
 
 var rmvCmd = &cobra.Command{
-	Use:   "delete-volume",
+	Use:     "delete-volume",
 	Aliases: []string{"rmv"},
-	Short: "Delete a unikernel volume",
+	Short:   "Delete a unikernel volume",
 	Long: `Deletes a volume.
-	You may specify the volume by name or id.`,
-	
+You may specify the volume by name or id.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/describe-image.go
+++ b/cmd/describe-image.go
@@ -1,20 +1,21 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
-	"os"
 	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var describeImageCmd = &cobra.Command{
 	Use:   "describe-image",
 	Short: "Get image info as a Json string",
-	Long: `Get a json representation of an image as it is stored in unik.`,
+	Long:  `Get a json representation of an image as it is stored in unik.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/describe-instance.go
+++ b/cmd/describe-instance.go
@@ -1,20 +1,21 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-	"os"
-	"github.com/Sirupsen/logrus"
 	"encoding/json"
-	"github.com/emc-advanced-dev/unik/pkg/client"
+	"fmt"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var describeInstanceCmd = &cobra.Command{
 	Use:   "describe-instance",
 	Short: "Get instance info as a Json string",
-	Long: `Get a json representation of an instance as it is stored in unik.`,
+	Long:  `Get a json representation of an instance as it is stored in unik.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/detach-volume.go
+++ b/cmd/detach-volume.go
@@ -1,25 +1,25 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var detachCmd = &cobra.Command{
-	Use:   "detach-volume",
+	Use:     "detach-volume",
 	Aliases: []string{"detach"},
-	Short: "Detach an attached volume from a stopped instance",
+	Short:   "Detach an attached volume from a stopped instance",
 	Long: `Detaches a volume to a stopped instance at a specified mount point.
-	You specify the volume by name or id.
+You specify the volume by name or id.
 
-	After detaching the volume, the volume can be mounted to another instance.
+After detaching the volume, the volume can be mounted to another instance.
 
-	If the instance is not stopped, detach will result in an error.
-	`,
-	
+If the instance is not stopped, detach will result in an error.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -1,19 +1,21 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/emc-advanced-dev/unik/pkg/client"
 	"os"
+
 	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var imagesCmd = &cobra.Command{
 	Use:   "images",
 	Short: "List available unikernel images",
 	Long: `Lists all available unikernel images across providers.
-	Includes important information for running and managing instances,
-	including bind mounts required at runtime.`,
+Includes important information for running and managing instances,
+including bind mounts required at runtime.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -1,18 +1,19 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var psCmd = &cobra.Command{
-	Use:   "instances",
+	Use:     "instances",
 	Aliases: []string{"ps"},
-	Short: "List pending/running/stopped unik instances",
-	Long: `Lists all unik-managed instances across providers.
-	`,
+	Short:   "List pending/running/stopped unik instances",
+	Long:    `Lists all unik-managed instances across providers.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,13 +1,15 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
-	"os"
-	"github.com/emc-advanced-dev/pkg/errors"
-	"fmt"
 	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var follow, deleteOnDisconnect bool
@@ -17,28 +19,28 @@ var logsCmd = &cobra.Command{
 	Short: "retrieve the logs (stdout) of a unikernel instance",
 	Long: `Retrieves logs from a running unikernel instance.
 
-	Cannot be used on an instance in powered-off state.
-	Use the --follow flag to attach to the instance's stdout
-	Use --delete in combination with --follow to force automatic instance
-	deletion when the HTTP connection to the instance is broken (by client
-	disconnect). The --delete flag is typically intended for use with
-	orchestration software such as cluster managers which may require
-	a persistent http connection managed instances.
+Cannot be used on an instance in powered-off state.
+Use the --follow flag to attach to the instance's stdout
+Use --delete in combination with --follow to force automatic instance
+deletion when the HTTP connection to the instance is broken (by client
+disconnect). The --delete flag is typically intended for use with
+orchestration software such as cluster managers which may require
+a persistent http connection managed instances.
 
-	You may specify the instance by name or id.
+You may specify the instance by name or id.
 
-	Example usage:
-		unik logs --instancce myInstance
+Example usage:
+	unik logs --instancce myInstance
 
-		# will return captured stdout from myInstance since boot time
+	# will return captured stdout from myInstance since boot time
 
-		unik logs --instance myInstance --follow --delete
+	unik logs --instance myInstance --follow --delete
 
-		# will open an http connection between the cli and unik
-		backend which streams stdout from the instance to the client
-		# when the client disconnects (i.e. with Ctrl+C) unik will
-		automatically power down and terminate the instance
-		`,
+	# will open an http connection between the cli and unik
+	backend which streams stdout from the instance to the client
+	# when the client disconnects (i.e. with Ctrl+C) unik will
+	automatically power down and terminate the instance
+`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -2,19 +2,20 @@ package cmd
 
 import (
 	"fmt"
-
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"strings"
 	"os"
-	"github.com/emc-advanced-dev/unik/pkg/client"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var providersCmd = &cobra.Command{
 	Use:   "providers",
 	Short: "List available unikernel providers",
-	Long: `Returns a list of providers available to the targeted unik backend.`,
+	Long:  `Returns a list of providers available to the targeted unik backend.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,15 +1,17 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/config"
-	"io/ioutil"
-	"gopkg.in/yaml.v2"
-	"os"
-	"fmt"
-	"github.com/emc-advanced-dev/unik/pkg/types"
 	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/emc-advanced-dev/unik/pkg/config"
+	"github.com/emc-advanced-dev/unik/pkg/types"
 )
 
 var clientConfigFile, host string
@@ -19,13 +21,13 @@ var RootCmd = &cobra.Command{
 	Use:   "unik",
 	Short: "The unikernel compilation, deployment, and management tool",
 	Long: `Unik is a tool for compiling application source code
-	into bootable disk images. Unik also runs and manages unikernel
-	instances across infrastructures.
+into bootable disk images. Unik also runs and manages unikernel
+instances across infrastructures.
 
-	Create a client configuration file with 'unik target'
+Create a client configuration file with 'unik target'
 
-	You may set a custom client configuration file w
-	ith the global flag --client-config=<path>`,
+You may set a custom client configuration file w
+ith the global flag --client-config=<path>`,
 }
 
 func init() {
@@ -35,23 +37,24 @@ func init() {
 }
 
 var clientConfig config.ClientConfig
+
 func readClientConfig() error {
 	data, err := ioutil.ReadFile(clientConfigFile)
 	if err != nil {
-		logrus.WithError(err).Errorf("failed to read client configuration file at "+ clientConfigFile +`\n
+		logrus.WithError(err).Errorf("failed to read client configuration file at " + clientConfigFile + `\n
 		Try setting your config with 'unik target HOST_URL'`)
 		return err
 	}
 	data = bytes.Replace(data, []byte("\n"), []byte{}, -1)
 	if err := yaml.Unmarshal(data, &clientConfig); err != nil {
-		logrus.WithError(err).Errorf("failed to parse client configuration yaml at "+ clientConfigFile +`\n
+		logrus.WithError(err).Errorf("failed to parse client configuration yaml at " + clientConfigFile + `\n
 		Please ensure config file contains valid yaml.'`)
 		return err
 	}
 	return nil
 }
 
-func printImages(images ... *types.Image) {
+func printImages(images ...*types.Image) {
 	fmt.Printf("%-20s %-20s %-20s %-20s %-6s %-20s\n", "NAME", "ID", "INFRASTRUCTURE", "CREATED", "SIZE(MB)", "MOUNTPOINTS")
 	for _, image := range images {
 		printImage(image)
@@ -71,7 +74,7 @@ func printImage(image *types.Image) {
 	}
 }
 
-func printInstances(instance ... *types.Instance) {
+func printInstances(instance ...*types.Instance) {
 	fmt.Printf("%-15s %-20s %-14s %-20s %-20s %-14s %-12s\n",
 		"NAME", "ID", "INFRASTRUCTURE", "CREATED", "IMAGE", "IPADDRESS", "STATE")
 	for _, instance := range instance {
@@ -84,7 +87,7 @@ func printInstance(instance *types.Instance) {
 		instance.Name, instance.Id, instance.Infrastructure, instance.Created.String(), instance.ImageId, instance.IpAddress, instance.State)
 }
 
-func printVolumes(volume ... *types.Volume) {
+func printVolumes(volume ...*types.Volume) {
 	fmt.Printf("%-15.15s %-15.15s %-14.14s %-20.20s %-20.20v %-12.12s\n",
 		"NAME", "ID", "INFRASTRUCTURE", "CREATED", "ATTACHED-INSTANCE", "SIZE(MB)")
 	for _, volume := range volume {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,13 +1,15 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"os"
-	"github.com/emc-advanced-dev/unik/pkg/client"
-	"strings"
 	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var instanceName, imageName string
@@ -17,31 +19,31 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run a unikernel instance from a compiled image",
 	Long: `Deploys a running instance from a unik-compiled unikernel disk image.
-	The instance will be deployed on the provider the image was compiled for.
-	e.g. if the image was compiled for virtualbox, unik will attempt to deploy
-	the image on the configured virtualbox environment.
+The instance will be deployed on the provider the image was compiled for.
+e.g. if the image was compiled for virtualbox, unik will attempt to deploy
+the image on the configured virtualbox environment.
 
-	'unik run' requires a unik-managed volume (see 'unik volumes' and 'unik create volume')
-	to be attached and mounted to each mount point specified at image compilation time.
-	This means that if the image was compiled with two mount points, /data1 and /data2,
-	'unik run' requires 2 available volumes to be attached to the instance at runtime, which
-	must be specified with the flags --vol SOME_VOLUME_NAME:/data1 --vol ANOTHER_VOLUME_NAME:/data2
-	If no mount points are required for the image, volumes cannot be attached.
+'unik run' requires a unik-managed volume (see 'unik volumes' and 'unik create volume')
+to be attached and mounted to each mount point specified at image compilation time.
+This means that if the image was compiled with two mount points, /data1 and /data2,
+'unik run' requires 2 available volumes to be attached to the instance at runtime, which
+must be specified with the flags --vol SOME_VOLUME_NAME:/data1 --vol ANOTHER_VOLUME_NAME:/data2
+If no mount points are required for the image, volumes cannot be attached.
 
-	environment variables can be set at runtime through the use of the -env flag.
+environment variables can be set at runtime through the use of the -env flag.
 
-	Example usage:
-		unik run --instanceName newInstance --imageName myImage --vol myVol:/mount1 --vol yourVol:/mount2 --env foo=bar --env another=one
+Example usage:
+	unik run --instanceName newInstance --imageName myImage --vol myVol:/mount1 --vol yourVol:/mount2 --env foo=bar --env another=one
 
-		# will create and run an instance of myImage on the provider environment myImage is compiled for
-		# instance will be named newInstance
-		# instance will attempt to mount unik-managed volume myVol to /mount1
-		# instance will attempt to mount unik-managed volume yourVol to /mount2
-		# instance will boot with env variable 'foo' set to 'bar'
-		# instance will boot with env variable 'another' set to 'one'
+	# will create and run an instance of myImage on the provider environment myImage is compiled for
+	# instance will be named newInstance
+	# instance will attempt to mount unik-managed volume myVol to /mount1
+	# instance will attempt to mount unik-managed volume yourVol to /mount2
+	# instance will boot with env variable 'foo' set to 'bar'
+	# instance will boot with env variable 'another' set to 'one'
 
-		# note that run must take exactly one --vol argument for each mount point defined in the image specification
-	`,
+	# note that run must take exactly one --vol argument for each mount point defined in the image specification
+`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if instanceName == "" {
@@ -81,10 +83,10 @@ var runCmd = &cobra.Command{
 
 			logrus.WithFields(logrus.Fields{
 				"instanceName": instanceName,
-				"imageName": imageName,
-				"env": env,
-				"mounts": mounts,
-				"host": host,
+				"imageName":    imageName,
+				"env":          env,
+				"mounts":       mounts,
+				"host":         host,
 			}).Infof("running unik run")
 			instance, err := client.UnikClient(host).Instances().Run(instanceName, imageName, mounts, env, noCleanup)
 			if err != nil {

--- a/cmd/start-instance.go
+++ b/cmd/start-instance.go
@@ -1,18 +1,20 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start a stopped unikernel instance",
 	Long: `Starts a stopped instance.
-	You may specify the instance by name or id.`,
+You may specify the instance by name or id.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/stop-instance.go
+++ b/cmd/stop-instance.go
@@ -1,18 +1,20 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/unik/pkg/client"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop a running unikernel instance",
 	Long: `Stops a running instance.
-	You may specify the instance by name or id.`,
+You may specify the instance by name or id.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {

--- a/cmd/target.go
+++ b/cmd/target.go
@@ -3,13 +3,15 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-	"github.com/emc-advanced-dev/unik/pkg/config"
-	"github.com/emc-advanced-dev/pkg/errors"
 	"io/ioutil"
-	"github.com/Sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/config"
 )
 
 var show bool
@@ -18,13 +20,13 @@ var targetCmd = &cobra.Command{
 	Use:   "target",
 	Short: "Configure unik daemon URL for cli client commands",
 	Long: `Sets the host url of the unik daemon for cli commands.
-	If running unik locally, use 'unik target --host localhost'
+If running unik locally, use 'unik target --host localhost'
 
-	args:
-	--host: <string, required>: host/ip address of the host running the unik daemon
-	--port: <int, optional>: port the daemon is running on (default: 3000)
+args:
+--host: <string, required>: host/ip address of the host running the unik daemon
+--port: <int, optional>: port the daemon is running on (default: 3000)
 
-	--show: <bool,optional>: shows the current target that is set`,
+--show: <bool,optional>: shows the current target that is set`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if show {
@@ -54,8 +56,8 @@ func setClientConfig(host string, port int) error {
 	if err != nil {
 		return errors.New("failed to convert config to yaml string ", err)
 	}
-	if err := ioutil.WriteFile(clientConfigFile, data, 0644); err !=nil {
-		return errors.New("failed writing config to file "+ clientConfigFile, err)
+	if err := ioutil.WriteFile(clientConfigFile, data, 0644); err != nil {
+		return errors.New("failed writing config to file "+clientConfigFile, err)
 	}
 	return nil
 }

--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/emc-advanced-dev/unik/pkg/client"
 	"os"
+
 	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
 )
 
 var volumesCmd = &cobra.Command{
@@ -13,9 +15,9 @@ var volumesCmd = &cobra.Command{
 	Short: "List available unik-managed volumes",
 	Long: `Lists all available unik-managed volumes across providers.
 
-	ATTACHED-INSTANCE gives the instance ID of the instance a volume
-	is attached to, if any. Only volumes that have no attachment are
-	available to be attached to an instance.`,
+ATTACHED-INSTANCE gives the instance ID of the instance a volume
+is attached to, if any. Only volumes that have no attachment are
+available to be attached to an instance.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := func() error {
 			if err := readClientConfig(); err != nil {


### PR DESCRIPTION
Closes #2

Also ran goimports, which separated stdlib/3rdparty/project imports and
did the gofmt job of indenting things.
