### PR TITLE
Adding --insecure to the curl command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 RUN apt-get update && apt-get install -y curl
 
-RUN curl https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz | sudo tar xz -C /usr/local
+RUN curl --insecure https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz | sudo tar xz -C /usr/local
 
 ENV GOROOT=/usr/local/go
 ENV GOPATH=$HOME/go


### PR DESCRIPTION
To avoid issues when internet traffic is intercepted and decrypted by a corporate firewall
