### PR TITLE
example command s,xen,aws,

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -39,7 +39,7 @@ Image names must be unique. If an image exists with the same name, you can force
 --force flag
 
 Example usage:
-	unik build --name myUnikernel --path ./myApp/src --compiler rump-go-xen --provider aws --mountpoint /foo --mountpoint /bar --args '-myParameter MYVALUE' --force
+	unik build --name myUnikernel --path ./myApp/src --compiler rump-go-aws --provider aws --mountpoint /foo --mountpoint /bar --args '-myParameter MYVALUE' --force
 
 	# will create a unikernel named myUnikernel using the sources found in ./myApp/src,
 	# compiled using rumprun for the xen hypervisor, targeting AWS infrastructure,


### PR DESCRIPTION
Fix for #37

Updated `unik build` example command to replace the xen compiler with the aws compiler.
