### PR TITLE
Makefile fix. Remove erroneous w on line 52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ pull:
 	docker pull projectunik/compilers-rump-nodejs-hw-no-stub$(CONTAINERTAG)
 	docker pull projectunik/compilers-rump-nodejs-xen$(CONTAINERTAG)
 	docker pull projectunik/compilers-rump-python3-hw$(CONTAINERTAG)
-	docker pull projectunik/compilers-rump-python3-hw-no-stubw$(CONTAINERTAG)
+	docker pull projectunik/compilers-rump-python3-hw-no-stub$(CONTAINERTAG)
 	docker pull projectunik/compilers-rump-python3-xen$(CONTAINERTAG)
 	docker pull projectunik/compilers-rump-base-xen$(CONTAINERTAG)
 	docker pull projectunik/compilers-rump-base-hw$(CONTAINERTAG)


### PR DESCRIPTION
Went to build unit this morning. Failed on the docker pull compilers-rump-python3-hw-no-stub. Noticed a w trailing stub. Removing the w resolved the issue ;)
