### PR TITLE
fix readClientConfig error message output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,13 +41,13 @@ var clientConfig config.ClientConfig
 func readClientConfig() error {
 	data, err := ioutil.ReadFile(clientConfigFile)
 	if err != nil {
-		logrus.WithError(err).Errorf("failed to read client configuration file at " + clientConfigFile + `\n
+		logrus.WithError(err).Errorf("failed to read client configuration file at " + clientConfigFile + `
 Try setting your config with 'unik target --host HOST_URL'`)
 		return err
 	}
 	data = bytes.Replace(data, []byte("\n"), []byte{}, -1)
 	if err := yaml.Unmarshal(data, &clientConfig); err != nil {
-		logrus.WithError(err).Errorf("failed to parse client configuration yaml at " + clientConfigFile + `\n
+		logrus.WithError(err).Errorf("failed to parse client configuration yaml at " + clientConfigFile + `
 Please ensure config file contains valid yaml.'\n
 Try setting your config with 'unik target --host HOST_URL'`)
 		return err


### PR DESCRIPTION
When using raw string literals to output error messages, the '\n' is not needed (and shows up unescaped in the output):

```
$ unik compilers
ERRO[0000] failed to read client configuration file at /Users/ingve/.unik/client-config.yaml\n
Try setting your config with 'unik target --host HOST_URL'  error=open /Users/ingve/.unik/client-config.yaml: no such file or directory
```

(Notice the unescaped **\n** at the end of the line beginning with ERRO[0000])
Removing the '\n' sequences gives correct output:

```
ERRO[0000] failed to read client configuration file at /Users/ingve/.unik/client-config.yaml
Try setting your config with 'unik target --host HOST_URL'  error=open /Users/ingve/.unik/client-config.yaml: no such file or directory
```
