### PR TITLE
updated link to config file example

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,8 +26,8 @@ instances across infrastructures.
 
 Create a client configuration file with 'unik target'
 
-You may set a custom client configuration file w
-ith the global flag --client-config=<path>`,
+You may set a custom client configuration file
+with the global flag --client-config=<path>`,
 }
 
 func init() {

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -11,7 +11,7 @@ Starting the UniK daemon with `unik daemon` requires a `yaml` file with configur
 
 By default, `unik daemon` reads from a configuration file located at `$HOME/.unik/daemon-config.yaml`. We recommend placing your config file there. However, you can specify a different config file with `unik daemon --f <path-to-file>`.
 
-UniK requires valid `yaml` matching the following [example](docs/examples/example-daemon-config.yaml):
+UniK requires valid `yaml` matching the following [example](examples/example-daemon-conf.yml):
 ```yaml
 providers:
   aws:


### PR DESCRIPTION
The provided markdown filename in the "Example" link does not match the actual example file; the path is different, the filename is different, and the file extension is different. 

This change updates the path/name/extension used in the markdown link so that prospective users can follow the link instead of getting a 404 error from GitHib, but the example file name and extension does not match what the rest of the text refers to. (In the text the file is referred to as "deamon-config" with extension "yaml" but the example uses the name "daemon-conf" instead of -config and the extension "yml") (Disregarding the "example" portion of the latter file name)) It would probably be more intuitive if the example file matched the naming convention used in the text.
