### PR TITLE
improved remove-containers in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ define build_container
 endef
 
 define remove_container
-	docker rmi -f projectunik/$(1):$(shell cat containers/versions.json  | jq .['$(1)'])
+	docker rmi -f projectunik/$(1):$(shell cat containers/versions.json  | jq '.["$(1)"]')
 endef
 
 all: pull ${SOURCES} binary
@@ -106,7 +106,7 @@ compilers: compilers-rump-go-hw \
            compilers-rump-python3-xen \
            compilers-osv-java
 
-compilers-rump-base-common: 
+compilers-rump-base-common:
 	$(call build_container,compilers/rump/base,$@,.common)
 
 compilers-rump-base-hw: compilers-rump-base-common
@@ -156,12 +156,12 @@ compilers-osv-java:
 #utils
 utils: boot-creator image-creator vsphere-client qemu-util
 
-boot-creator: 
+boot-creator:
 	cd containers/utils/boot-creator && GO15VENDOREXPERIMENT=1 GOOS=linux go build -tags container-binary
 	$(call build_container,utils/boot-creator,$@,)
 	cd containers/utils/boot-creator && rm boot-creator
 
-image-creator: 
+image-creator:
 	cd containers/utils/image-creator && GO15VENDOREXPERIMENT=1 GOOS=linux go build -tags container-binary
 	$(call build_container,utils/image-creator,$@,)
 	cd containers/utils/image-creator && rm image-creator
@@ -175,7 +175,7 @@ containers/utils/vsphere-client/vsphere-client.empty: $(VSPHERE_CLIENT_SOURCES)
 	cd containers/utils/vsphere-client && rm -rf target
 	touch containers/utils/vsphere-client/vsphere-client.empty
 
-qemu-util: 
+qemu-util:
 	$(call build_container,utils/qemu-util,$@,)
 
 #------


### PR DESCRIPTION
`make remove-containers` generates a lot of error messages and fails to remove the containers:

```
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/vsphere-client:
Error response from daemon: Error parsing reference: "projectunik/vsphere-client:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
rm -rf containers/utils/vsphere-client/vsphere-client.empty
docker rmi -f projectunik/image-creator:
Error response from daemon: Error parsing reference: "projectunik/image-creator:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/boot-creator:
Error response from daemon: Error parsing reference: "projectunik/boot-creator:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-osv-java:
Error response from daemon: Error parsing reference: "projectunik/compilers-osv-java:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-go-xen:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-go-xen:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-go-hw:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-go-hw:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-go-hw-no-stub:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-go-hw-no-stub:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-nodejs-hw:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-nodejs-hw:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-nodejs-hw-no-stub:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-nodejs-hw-no-stub:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-nodejs-xen:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-nodejs-xen:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-python3-hw:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-python3-hw:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-python3-hw-no-stub:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-python3-hw-no-stub:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-python3-xen:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-python3-xen:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-base-xen:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-base-xen:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-base-hw:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-base-hw:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/rump-debugger-qemu:
Error response from daemon: Error parsing reference: "projectunik/rump-debugger-qemu:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
docker rmi -f projectunik/compilers-rump-base-common:
Error response from daemon: Error parsing reference: "projectunik/compilers-rump-base-common:" is not a valid repository/tag
make: [remove-containers] Error 1 (ignored)
```

As you can see, the images are not removed:

```
$ docker images
projectunik/compilers-osv-java                  188ed2ad3483697e    188ed2ad3483        3 weeks ago         1.594 GB
projectunik/boot-creator                        3cf35a75988c907f    3cf35a75988c        3 weeks ago         243.7 MB
projectunik/compilers-rump-go-hw-no-stub        ef22bdc13e711e5b    ef22bdc13e71        3 weeks ago         2.368 GB
projectunik/vsphere-client                      2ea0e4e7fafa7645    2ea0e4e7fafa        3 weeks ago         1.008 GB
projectunik/compilers-rump-python3-xen          9db1322ed9ec1240    9db1322ed9ec        4 weeks ago         2.849 GB
projectunik/compilers-rump-python3-hw           87a1e7336a415f08    87a1e7336a41        4 weeks ago         3.156 GB
projectunik/compilers-rump-python3-hw-no-stub   0987f5c0409caaa7    0987f5c0409c        4 weeks ago         3.185 GB
projectunik/qemu-util                           a73fcb7905a05552    a73fcb7905a0        4 weeks ago         474.1 MB
projectunik/compilers-rump-nodejs-xen           33adb8232988d249    33adb8232988        4 weeks ago         1.925 GB
projectunik/compilers-rump-nodejs-hw            ca39f4c5d9f4a4af    ca39f4c5d9f4        4 weeks ago         2.235 GB
projectunik/compilers-rump-nodejs-hw-no-stub    8f8a684f3a86d866    8f8a684f3a86        4 weeks ago         2.235 GB
projectunik/compilers-rump-go-xen               711c71ecd7ac0124    711c71ecd7ac        4 weeks ago         2.061 GB
projectunik/compilers-rump-base-xen             1ae58a3b3be9328f    1ae58a3b3be9        4 weeks ago         1.457 GB
projectunik/rump-debugger-qemu                  49f1796b79f46203    49f1796b79f4        4 weeks ago         2.232 GB
projectunik/compilers-rump-go-hw                dcc22a34cad8c12a    dcc22a34cad8        4 weeks ago         2.368 GB
projectunik/compilers-rump-base-hw              73dc1ffd2662db5e    73dc1ffd2662        4 weeks ago         1.764 GB
projectunik/compilers-rump-base-common          318a68891a0d785f    318a68891a0d        4 weeks ago         737.1 MB

```

This is caused by containers having hyphens in their names, so `jq` does not get the correct information from `versions.json`.

Changing the Makefile rule from 

```
define remove_container
    docker rmi -f projectunik/$(1):$(shell cat containers/versions.json  | jq .['$(1)'])
endef
```

to

```
define remove_container
    docker rmi -f projectunik/$(1):$(shell cat containers/versions.json  | jq '.["$(1)"]'
endef
```

fixes the problem, and now the images are actually deleted.
