### PR TITLE
Documentation fixes, minor Makefile update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ define remove_container
 	docker rmi -f projectunik/$(1):$(shell cat containers/versions.json  | jq '.["$(1)"]')
 endef
 
-all: pull ${SOURCES} binary 
+all: pull ${SOURCES} binary
 
 .PHONY: submodules
 .PHONY: pull
@@ -76,7 +76,7 @@ submodules:
 
 #pull containers
 pull:
-	echo "Pullling containers from docker hub"
+	@echo "Pullling containers from docker hub"
 	$(call pull_container,vsphere-client)
 	$(call pull_container,boot-creator)
 	$(call pull_container,qemu-util)
@@ -217,12 +217,12 @@ ifeq (,$(TARGET_OS))
 	echo "Unknown platform $(TARGET_OS)"
 	exit 1
 endif
-	echo Building for platform $(UNAME)
+	@echo Building for platform $(UNAME)
 	docker build -t projectunik/$@ -f Dockerfile .
 	mkdir -p ./_build
 	docker run --rm -v $(shell pwd)/_build:/opt/build -e TARGET_OS=$(TARGET_OS) -e CONTAINERVER=$(CONTAINERVER) projectunik/$@
 	#docker rmi -f projectunik/$@
-	echo "Install finished! UniK binary can be found at $(shell pwd)/_build/unik"
+	@echo "Install finished! UniK binary can be found at $(shell pwd)/_build/unik"
 #----
 
 # local build - useful if you have development env setup. if not - use binary! (this can't depend on binary as binary depends on it via the Dockerfile)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -242,7 +242,7 @@ unik start --instance INSTANCE_NAME
 
 #### Retrieve or Follow Instance Logs
 ```
-unik start --instance INSTANCE_NAME
+unik logs --instance INSTANCE_NAME
 ```
 Retrieves logs from a running unikernel instance.
 
@@ -256,7 +256,7 @@ a persistent http connection managed instances.
 
 Example usage:
 ```
-unik logs --instancce myInstance
+unik logs --instance myInstance
 ```
 * will return captured stdout from myInstance since boot time
 
@@ -271,13 +271,13 @@ unik logs --instance myInstance --follow --delete
 ##### Create a Volume
 
 ```
-
+unik create-volume
 ```
-reate a data volume which can be attached to and detached from
+Creates a data volume which can be attached to and detached from
 unik-managed instances.
 
 Volumes can be created from a directory, which will copy the contents
-of the directory onto the voume. Empty volume can also be created.
+of the directory onto the volume. Empty volume can also be created.
 
 Volumes will persist after instances are deleted, allowing application data
 to be persisted beyond the lifecycle of individual instances.
@@ -287,7 +287,7 @@ not necessary. UniK will automatically size the volume to fit the data provided.
 A larger volume can be requested with the --size flag.
 
 If no data directory is provided, --size is a required parameter to specify the
-desired size for the empty volume to be createad.
+desired size for the empty volume to be created.
 
 Volumes are created for a specific provider, specified with the --provider flag.
 Volumes can only be attached to instances of the same provider type.

--- a/docs/compilers/includeos.md
+++ b/docs/compilers/includeos.md
@@ -1,9 +1,9 @@
 # IncludeOS Unikernels
 
-UniK uses [IncludeOS](http://www.includeos.org/) as a platform for compiling C++ applications to unikernels. Building IncludeOS unikernels requires conforming to the structure of an IncludeOS project, documented [here](https://github.com/hioa-cs/IncludeOS/wiki/Creating-your-first-IncludeOS-service), with an example  [here](https://github.com/hioa-cs/IncludeOS/tree/master/seed).
+UniK uses [IncludeOS](http://www.includeos.org/) as a platform for compiling C++ applications to unikernels. Building IncludeOS unikernels requires conforming to the structure of an IncludeOS project, [documented here](https://github.com/hioa-cs/IncludeOS/wiki/Creating-your-first-IncludeOS-service), with an [example here](https://github.com/hioa-cs/IncludeOS/tree/master/seed).
 
-You can also see the [example in the examples directory](../examples/example-cpp-includeos)
+You can also see an [example here](https://github.com/includeos/unik_test_service)
 
 Your application code will be called from ```Service::start()``` in `service.cpp`
 
-Note the line `unik::register_instance();` in [service.cpp#L41](../examples/example-cpp-includeos/service.cpp#L41): this line (and the imported file `#include <unik>`) are required for registering instances of your application to UniK. Without this, UniK will be unable to IPs of your instances (they will run otherwise normally).
+Note the line `unik::register_instance();` in [service.cpp#L41](https://github.com/includeos/unik_test_service/blob/master/service.cpp#L41): this line (and the imported file `#include <unik>`) are required for registering instances of your application to UniK. Without this, UniK will be unable to determine and display IPs of your instances (they will run otherwise normally).

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -77,7 +77,7 @@ In the Virtualbox stub:
 #### AWS
 AWS provider in UniK assumes use of default AWS credential chain. This means either [setting AWS access key id and secret key in your environment](http://docs.aws.amazon.com/aws-sdk-php/v2/guide/credentials.html#environment-credentials), or using the default [AWS configuration file](http://docs.aws.amazon.com/cli/latest/topic/config-vars.html).
 
-Region and zone should be speified like so in the AWS stub:
+Region and zone should be specified like so in the AWS stub:
 ```yaml
   aws:
     - name: any-name-you-want

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -89,7 +89,7 @@ Ensure that each of the following are installed
   ```
 
 2. Try running this code with `go run http.go`. Visit [http://localhost:8080/](http://localhost:8080/) to see that the server is running.
-3. We need to create a dummy `Godeps` file. This is necessary to tell the Go compiler how Go projects and their dependencies are structured. Fortunately, with this example, our project has no dependencies, and we can just fill out a simple `Godeps` file without installing [`godep`](https://github.com/tools/godep). Note: for Go projects with imported dependencies, and nested packages, you will need to install Godeps and run `GO15VENDOREXPERIMENT=1 godep save ./...` in your project. see [Compiling Go Apps with UniK](compilers/rump.md#golang) for more information.
+3. We need to create a dummy `Godeps` file. This is necessary to tell the Go compiler how Go projects and their dependencies are structured. Fortunately, with this example, our project has no dependencies, and we can just fill out a simple `Godeps` file without installing [`godep`](https://github.com/tools/godep). Note: for Go projects with imported dependencies, and nested packages, you will need to install Godeps and run `GO15VENDOREXPERIMENT=1 godep save ./...` in your project. See [Compiling Go Apps with UniK](compilers/rump.md#golang) for more information.
   * To create the dummy Godeps file, create a folder named `Godeps` in the same directory as `httpd.go`. Inside, create a file named `Godeps.json` and paste the following inside:
   ```json
   {
@@ -119,7 +119,7 @@ Ensure that each of the following are installed
   ```
   unik build --name myImage --path ./ --compiler rump-go-virtualbox --provider virtualbox
   ```
-  this command will instruct UniK to compile the sources found in the working directory (`./`) using the `rump-go-virtualbox` compiler, and stage the image for running the `virtualbox` provider.
+  This command will instruct UniK to compile the sources found in the working directory (`./`) using the `rump-go-virtualbox` compiler, and stage the image for running the `virtualbox` provider.
 2. You can watch the output of the `build` command in the terminal window running the daemon.
 3. When `build` finishes, the resulting disk image will reside at `$HOME/.unik/virtualbox/images/myImage/boot.vmdk`
 4. Run an instance of this image with

--- a/docs/getting_started_node.md
+++ b/docs/getting_started_node.md
@@ -89,7 +89,7 @@ Ensure that each of the following are installed
 
   Try running this code with `node server.js`. Visit [http://localhost:8080/](http://localhost:8080/) to see that the server is running.
 
-    *Note:* for Node.js projects with imported dependencies, you will need to install npm and run `npm install <package_name>` for each package yuor application requires.See [Compiling Node.js Apps with UniK](compilers/rump.md#nodejs) for more information.
+    *Note:* for Node.js projects with imported dependencies, you will need to install npm and run `npm install <package_name>` for each package your application requires. See [Compiling Node.js Apps with UniK](compilers/rump.md#nodejs) for more information.
 
 5. We need to create a manifest file to tell UniK the name of the file which contains the entrypoint to our application. In this case, it's just `server.js`.
 

--- a/docs/instance_listener.md
+++ b/docs/instance_listener.md
@@ -9,4 +9,4 @@ There is no additional configuration necessary to deploy the instance listener. 
 The code for the instance listener can be found [here](https://github.com/emc-advanced-dev/unik/tree/master/instance-listener).
 
 
-UniK Instances depend on the instance listener at for bootstrapping information when they boot. If your instances are not booting properly, check that the Instance Listener is alive and responding to requests on port `3000`. If the instance listener fails to respond, you can restart it. Or, simply restart the **daemon**, and UniK will automatically re-deploy the instance listener.
+UniK Instances depend on the instance listener for bootstrapping information when they boot. If your instances are not booting properly, check that the Instance Listener is alive and responding to requests on port `3000`. If the instance listener fails to respond, you can restart it. Or, simply restart the **daemon**, and UniK will automatically re-deploy the instance listener.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -26,7 +26,7 @@ type Provider interface {
 }
 ```
 
-**Providers** handle the long-term management of UniK's principle object types:
+**Providers** handle the long-term management of UniK's principal object types:
 * Images
 * Instances
 * Volumes

--- a/pkg/providers/aws/aws_provider.go
+++ b/pkg/providers/aws/aws_provider.go
@@ -14,7 +14,7 @@ import (
 )
 
 func AwsStateFile() string {
-	return filepath.Join(config.Internal.UnikHome, "aws/state.json")
+	return filepath.Join(config.Internal.UnikHome, "aws", "state.json")
 }
 
 type AwsProvider struct {


### PR DESCRIPTION
Some minor issues we noticed while working on the IncludeOS support: mostly errors/typos in the docs, plus the links to the IncludeOS example in docs/examples does not work on GitHub, possibly because it is added as a submodule? Replaced with links to our example repo.
