### PR TITLE
Refactor OSv compiler to make it extensible

### DIFF
--- a/pkg/compilers/osv/generic.go
+++ b/pkg/compilers/osv/generic.go
@@ -1,72 +1,9 @@
 package osv
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
-	"github.com/Sirupsen/logrus"
-	"github.com/emc-advanced-dev/pkg/errors"
 	"github.com/emc-advanced-dev/unik/pkg/types"
-	unikutil "github.com/emc-advanced-dev/unik/pkg/util"
-	"gopkg.in/yaml.v2"
-	"strings"
 )
 
-
-type javaProjectConfig struct {
-	ArtifactFilename string `yaml:"artifact_filename"`
-	BuildCmd string `yaml:"build_command"`
-	Properties []string `yaml:"properties"`
-}
-
-func compileRawImage(params types.CompileImageParams, useEc2Bootstrap bool) (string, error) {
-	sourcesDir := params.SourcesDir
-
-	var config javaProjectConfig
-	data, err := ioutil.ReadFile(filepath.Join(sourcesDir, "manifest.yaml"))
-	if err != nil {
-		return "", errors.New("failed to read manifest.yaml file", err)
-	}
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return "", errors.New("failed to parse yaml manifest.yaml file", err)
-	}
-
-	container := unikutil.NewContainer("compilers-osv-java").WithVolume("/dev", "/dev").WithVolume(sourcesDir+"/", "/project_directory")
-	var args []string
-	if useEc2Bootstrap {
-		args = append(args, "-ec2")
-	}
-
-	args = append(args, "-artifactName", config.ArtifactFilename)
-	args = append(args, "-args", params.Args)
-	if config.BuildCmd != "" {
-		args = append(args, "-buildCmd", config.BuildCmd)
-	}
-	if len(config.Properties) > 0 {
-		args = append(args, "-properties", strings.Join(config.Properties, " "))
-	}
-
-	logrus.WithFields(logrus.Fields{
-		"args": args,
-	}).Debugf("running compilers-osv-java container")
-
-	if err := container.Run(args...); err != nil {
-		return "", errors.New("failed running compilers-osv-java on "+sourcesDir, err)
-	}
-
-	resultFile, err := ioutil.TempFile("", "osv-boot.vmdk.")
-	if err != nil {
-		return "", errors.New("failed to create tmpfile for result", err)
-	}
-	defer func() {
-		if err != nil && !params.NoCleanup {
-			os.Remove(resultFile.Name())
-		}
-	}()
-
-	if err := os.Rename(filepath.Join(sourcesDir, "boot.qcow2"), resultFile.Name()); err != nil {
-		return "", errors.New("failed to rename result file", err)
-	}
-	return resultFile.Name(), nil
+type OSvCompilerBase struct {
+	CreateImage func(params types.CompileImageParams, useEc2Bootstrap bool) (string, error)
 }

--- a/pkg/compilers/osv/osv_aws.go
+++ b/pkg/compilers/osv/osv_aws.go
@@ -1,24 +1,25 @@
 package osv
 
 import (
-	"github.com/emc-advanced-dev/unik/pkg/types"
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/types"
 )
 
 type OsvAwsCompiler struct {
+	OSvCompilerBase
 }
 
 const OSV_AWS_MEMORY = 1024
 
 func (osvCompiler *OsvAwsCompiler) CompileRawImage(params types.CompileImageParams) (_ *types.RawImage, err error) {
-	resultFile, err := compileRawImage(params, true)
+	resultFile, err := osvCompiler.CreateImage(params, true)
 	if err != nil {
 		return nil, errors.New("failed to compile raw osv image", err)
 	}
 	return &types.RawImage{
 		LocalImagePath: resultFile,
 		StageSpec: types.StageSpec{
-			ImageFormat: types.ImageFormat_QCOW2,
+			ImageFormat:           types.ImageFormat_QCOW2,
 			XenVirtualizationType: types.XenVirtualizationType_HVM,
 		},
 		RunSpec: types.RunSpec{

--- a/pkg/compilers/osv/osv_java.go
+++ b/pkg/compilers/osv/osv_java.go
@@ -1,0 +1,73 @@
+package osv
+
+import (
+	"os"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/types"
+	unikutil "github.com/emc-advanced-dev/unik/pkg/util"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"path/filepath"
+)
+
+// javaProjectConfig defines available inputs
+type javaProjectConfig struct {
+	ArtifactFilename string   `yaml:"artifact_filename"`
+	BuildCmd         string   `yaml:"build_command"`
+	Properties       []string `yaml:"properties"`
+}
+
+// CreateImageJava creates OSv image from project source code and returns filepath of it.
+func CreateImageJava(params types.CompileImageParams, useEc2Bootstrap bool) (string, error) {
+	sourcesDir := params.SourcesDir
+
+	var config javaProjectConfig
+	data, err := ioutil.ReadFile(filepath.Join(sourcesDir, "manifest.yaml"))
+	if err != nil {
+		return "", errors.New("failed to read manifest.yaml file", err)
+	}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return "", errors.New("failed to parse yaml manifest.yaml file", err)
+	}
+
+	container := unikutil.NewContainer("compilers-osv-java").WithVolume("/dev", "/dev").WithVolume(sourcesDir+"/", "/project_directory")
+	var args []string
+	if useEc2Bootstrap {
+		args = append(args, "-ec2")
+	}
+
+	args = append(args, "-artifactName", config.ArtifactFilename)
+	args = append(args, "-args", params.Args)
+	if config.BuildCmd != "" {
+		args = append(args, "-buildCmd", config.BuildCmd)
+	}
+	if len(config.Properties) > 0 {
+		args = append(args, "-properties", strings.Join(config.Properties, " "))
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"args": args,
+	}).Debugf("running compilers-osv-java container")
+
+	if err := container.Run(args...); err != nil {
+		return "", errors.New("failed running compilers-osv-java on "+sourcesDir, err)
+	}
+
+	resultFile, err := ioutil.TempFile("", "osv-boot.vmdk.")
+	if err != nil {
+		return "", errors.New("failed to create tmpfile for result", err)
+	}
+	defer func() {
+		if err != nil && !params.NoCleanup {
+			os.Remove(resultFile.Name())
+		}
+	}()
+
+	if err := os.Rename(filepath.Join(sourcesDir, "boot.qcow2"), resultFile.Name()); err != nil {
+		return "", errors.New("failed to rename result file", err)
+	}
+	return resultFile.Name(), nil
+}

--- a/pkg/compilers/osv/osv_virtualbox.go
+++ b/pkg/compilers/osv/osv_virtualbox.go
@@ -1,18 +1,20 @@
 package osv
 
 import (
-	"github.com/emc-advanced-dev/unik/pkg/types"
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/types"
 )
 
 const OSV_VIRTUALBOX_MEMORY = 512
 
-type OsvVirtualboxCompiler struct {}
+type OsvVirtualboxCompiler struct {
+	OSvCompilerBase
+}
 
 func (osvCompiler *OsvVirtualboxCompiler) CompileRawImage(params types.CompileImageParams) (_ *types.RawImage, err error) {
-	resultFile, err := compileRawImage(params, false)
+	resultFile, err := osvCompiler.CreateImage(params, false)
 	if err != nil {
-		return nil, errors.New("failed to compile raw osv image", err)
+		return nil, errors.New("failed to compile raw OSv Java image", err)
 	}
 	return &types.RawImage{
 		LocalImagePath: resultFile,
@@ -23,7 +25,7 @@ func (osvCompiler *OsvVirtualboxCompiler) CompileRawImage(params types.CompileIm
 			DeviceMappings: []types.DeviceMapping{
 				types.DeviceMapping{MountPoint: "/", DeviceName: "/dev/sda1"},
 			},
-			StorageDriver: types.StorageDriver_SATA,
+			StorageDriver:         types.StorageDriver_SATA,
 			DefaultInstanceMemory: OSV_VIRTUALBOX_MEMORY,
 		},
 	}, nil

--- a/pkg/compilers/osv/osv_vmware.go
+++ b/pkg/compilers/osv/osv_vmware.go
@@ -1,17 +1,18 @@
 package osv
 
 import (
-	"github.com/emc-advanced-dev/unik/pkg/types"
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/types"
 )
 
-type OsvVmwareCompiler struct {}
-
+type OsvVmwareCompiler struct {
+	OSvCompilerBase
+}
 
 const OSV_VMWARE_MEMORY = 512
 
 func (osvCompiler *OsvVmwareCompiler) CompileRawImage(params types.CompileImageParams) (_ *types.RawImage, err error) {
-	resultFile, err := compileRawImage(params, false)
+	resultFile, err := osvCompiler.CreateImage(params, false)
 	if err != nil {
 		return nil, errors.New("failed to compile raw osv image", err)
 	}
@@ -24,8 +25,8 @@ func (osvCompiler *OsvVmwareCompiler) CompileRawImage(params types.CompileImageP
 			DeviceMappings: []types.DeviceMapping{
 				types.DeviceMapping{MountPoint: "/", DeviceName: "/dev/sda1"},
 			},
-			StorageDriver: types.StorageDriver_IDE,
-			VsphereNetworkType: types.VsphereNetworkType_VMXNET3,
+			StorageDriver:         types.StorageDriver_IDE,
+			VsphereNetworkType:    types.VsphereNetworkType_VMXNET3,
 			DefaultInstanceMemory: OSV_VMWARE_MEMORY,
 		},
 	}, nil

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -27,12 +27,12 @@ import (
 	"github.com/emc-advanced-dev/unik/pkg/providers/vsphere"
 	"github.com/emc-advanced-dev/unik/pkg/state"
 	"github.com/emc-advanced-dev/unik/pkg/types"
+	"github.com/emc-advanced-dev/unik/pkg/util"
 	"github.com/go-martini/martini"
 	"github.com/layer-x/layerx-commons/lxmartini"
+	"os/exec"
 	"path/filepath"
 	"runtime"
-	"os/exec"
-	"github.com/emc-advanced-dev/unik/pkg/util"
 	"sort"
 )
 
@@ -124,28 +124,28 @@ func NewUnikDaemon(config config.DaemonConfig) (*UnikDaemon, error) {
 
 	_compilers[compilers.RUMP_GO_AWS] = &rump.RumpGoCompiler{
 		RumCompilerBase: rump.RumCompilerBase{
-			DockerImage:   "compilers-rump-go-xen",
-			CreateImage:   rump.CreateImageAws,
+			DockerImage: "compilers-rump-go-xen",
+			CreateImage: rump.CreateImageAws,
 		},
 	}
 	_compilers[compilers.RUMP_GO_VMWARE] = &rump.RumpGoCompiler{
 		RumCompilerBase: rump.RumCompilerBase{
 
-			DockerImage:   "compilers-rump-go-hw",
-			CreateImage:   rump.CreateImageVmware,
+			DockerImage: "compilers-rump-go-hw",
+			CreateImage: rump.CreateImageVmware,
 		},
 	}
 	_compilers[compilers.RUMP_GO_VIRTUALBOX] = &rump.RumpGoCompiler{
 		RumCompilerBase: rump.RumCompilerBase{
 
-			DockerImage:   "compilers-rump-go-hw",
-			CreateImage:   rump.CreateImageVirtualBox,
+			DockerImage: "compilers-rump-go-hw",
+			CreateImage: rump.CreateImageVirtualBox,
 		},
 	}
 	_compilers[compilers.RUMP_GO_QEMU] = &rump.RumpGoCompiler{
 		RumCompilerBase: rump.RumCompilerBase{
-			DockerImage:   "compilers-rump-go-hw-no-stub",
-			CreateImage:   rump.CreateImageQemu,
+			DockerImage: "compilers-rump-go-hw-no-stub",
+			CreateImage: rump.CreateImageQemu,
 		},
 	}
 
@@ -178,8 +178,8 @@ func NewUnikDaemon(config config.DaemonConfig) (*UnikDaemon, error) {
 	}
 	_compilers[compilers.RUMP_NODEJS_QEMU] = &rump.RumpScriptCompiler{
 		RumCompilerBase: rump.RumCompilerBase{
-			DockerImage:   "compilers-rump-nodejs-hw-no-stub",
-			CreateImage:   rump.CreateImageQemu,
+			DockerImage: "compilers-rump-nodejs-hw-no-stub",
+			CreateImage: rump.CreateImageQemu,
 		},
 		RunScriptArgs: "/bootpart/node-wrapper.js",
 	}
@@ -189,9 +189,21 @@ func NewUnikDaemon(config config.DaemonConfig) (*UnikDaemon, error) {
 	_compilers[compilers.RUMP_PYTHON_VMWARE] = rump.NewRumpPythonCompiler("compilers-rump-python3-hw", rump.CreateImageVmwareAddStub, rump.BootstrapTypeUDP)
 	_compilers[compilers.RUMP_PYTHON_QEMU] = rump.NewRumpPythonCompiler("compilers-rump-python3-hw-no-stub", rump.CreateImageQemu, rump.BootstrapTypeUDP)
 
-	_compilers[compilers.OSV_JAVA_AWS] = &osv.OsvAwsCompiler{}
-	_compilers[compilers.OSV_JAVA_VIRTUALBOX] = &osv.OsvVirtualboxCompiler{}
-	_compilers[compilers.OSV_JAVA_VMAWRE] = &osv.OsvVmwareCompiler{}
+	_compilers[compilers.OSV_JAVA_AWS] = &osv.OsvAwsCompiler{
+		OSvCompilerBase: osv.OSvCompilerBase{
+			CreateImage: osv.CreateImageJava,
+		},
+	}
+	_compilers[compilers.OSV_JAVA_VIRTUALBOX] = &osv.OsvVirtualboxCompiler{
+		OSvCompilerBase: osv.OSvCompilerBase{
+			CreateImage: osv.CreateImageJava,
+		},
+	}
+	_compilers[compilers.OSV_JAVA_VMAWRE] = &osv.OsvVmwareCompiler{
+		OSvCompilerBase: osv.OSvCompilerBase{
+			CreateImage: osv.CreateImageJava,
+		},
+	}
 
 	d := &UnikDaemon{
 		server:    lxmartini.QuietMartini(),
@@ -339,7 +351,7 @@ func (d *UnikDaemon) addEndpoints() {
 				"args":         args,
 				"compiler":     compilerType,
 				"provider":     providerType,
-				"noCleanup":     noCleanup,
+				"noCleanup":    noCleanup,
 			}).Debugf("compiling raw image")
 
 			compileParams := types.CompileImageParams{
@@ -354,7 +366,6 @@ func (d *UnikDaemon) addEndpoints() {
 				return nil, http.StatusInternalServerError, errors.New("failed to compile raw image", err)
 			}
 			logrus.Debugf("raw image compiled and saved to " + rawImage.LocalImagePath)
-
 
 			if !noCleanup {
 				defer os.Remove(rawImage.LocalImagePath)
@@ -821,14 +832,14 @@ func (d *UnikDaemon) addEndpoints() {
 }
 
 func streamOutput(outputFunc func() (string, error), w io.Writer) (err error) {
-	defer func(){
+	defer func() {
 		if err != nil {
 			w.Write([]byte(err.Error()))
 		}
 	}()
 
 	//give instance some time to start logs server
-	if err := util.Retry(30, time.Millisecond * 500, func() error {
+	if err := util.Retry(30, time.Millisecond*500, func() error {
 		_, err := outputFunc()
 		return err
 	}); err != nil {


### PR DESCRIPTION
OSv compiler was hard-coded to compile Java apps only. Now, we are preparing OSv compiler for NodeJS apps, therefore simple refactoring was needed. Functionality should be exactly the same as before.

The difference that this PR introduces is that in `daemon.go` instead

```
_compilers[compilers.OSV_JAVA_VIRTUALBOX] = &osv.OsvVirtualboxCompiler{}
```

one must now pass the function `CreateImage`:

```
_compilers[compilers.OSV_JAVA_VIRTUALBOX] = &osv.OsvVirtualboxCompiler{
    OSvCompilerBase: osv.OSvCompilerBase{
        CreateImage: osv.CreateImageJava,
    },
}
```

Obviously, the idea is that with the next PR we will implement another `CreateImage` function.
