### PR TITLE
Modify the golang version to allow govmomi to compile

### DIFF
--- a/containers/utils/vsphere-client/Dockerfile
+++ b/containers/utils/vsphere-client/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:14.04
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && \
     apt-get install -y --force-yes git openjdk-7-jdk curl && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN curl https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz |  tar xz -C /usr/local &&  mv /usr/local/go /usr/local/go1.5 &&  ln -s /usr/local/go1.5 /usr/local/go
+RUN curl --insecure https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz |  tar xz -C /usr/local &&  mv /usr/local/go /usr/local/go1.7 &&  ln -s /usr/local/go1.7 /usr/local/go
 ENV GOPATH=$HOME/go
 ENV GOBIN=$GOPATH/bin
 ENV PATH=$GOBIN:/usr/local/go/bin:$PATH


### PR DESCRIPTION
Go 1.7 moves the golang.org/x/net/context package into the standard library as context.
