### PR TITLE
Implement dynamic OSv compiler

### DIFF
--- a/containers/compilers/osv/dynamic/Dockerfile
+++ b/containers/compilers/osv/dynamic/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:16.04
+
+# Install prerequisites
+RUN apt-get update -y
+RUN apt-get install -y curl git qemu
+
+# Install GO
+RUN curl https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz | tar xz -C /usr/local && \
+    mv /usr/local/go /usr/local/go1.6 && \
+    ln -s /usr/local/go1.6 /usr/local/go
+ENV GOPATH=/go
+ENV GOBIN=$GOPATH/bin
+ENV PATH=$GOBIN:/usr/local/go/bin:$PATH
+
+# Build Capstan from source (use mikelangelo-project fork that supports package management)
+RUN go get github.com/tools/godep && \
+    go get github.com/cloudius-systems/capstan && \
+    cd $GOPATH/src/github.com/cloudius-systems/capstan && \
+    git remote set-url origin https://github.com/mikelangelo-project/capstan.git && \
+    git fetch origin && \
+    git checkout develop && \
+    echo "Using forked capstan. Last commit was:" && \
+    git log -1 && \
+    godep restore && \
+    go install
+
+# Copy files needed by docker container
+COPY docker_files/root /root
+
+# Create mount point directory
+RUN mkdir /project_directory
+
+# Compose boot image and copy it to /project_directory (unik expects it there as a result)
+CMD cd /project_directory && \
+    capstan pull mike/osv-loader && \
+    capstan package compose unik/dynamic-image --pull-missing --size $MAX_IMAGE_SIZE && \	
+    cp /root/.capstan/repository/unik/dynamic-image/dynamic-image.qemu /project_directory/boot.qcow2
+
+#
+# NOTES
+#
+# Build this container with:
+# docker build -t projectunik/compilers-osv-dynamic:v0.0 . --no-cache
+#
+# Run this container with:
+# docker run -ti --volume="$PWD:/project_directory" --env MAX_IMAGE_SIZE=500MB projectunik/compilers-osv-dynamic:v0.0
+#

--- a/containers/compilers/osv/dynamic/docker_files/root/.capstan/config.yaml
+++ b/containers/compilers/osv/dynamic/docker_files/root/.capstan/config.yaml
@@ -1,0 +1,8 @@
+# Where is repository with prebuilt OSv packages.
+repo_url: https://mikelangelo-capstan.s3.amazonaws.com/
+
+# Don't use KVM feature.
+# This feature requires exclusive access so if any other
+# hypervisor (besides qemu) locks it, then 'capstan package compose'
+# would result in error.
+disable_kvm: true

--- a/containers/versions.json
+++ b/containers/versions.json
@@ -23,5 +23,6 @@
   "compilers-rump-base-hw": "8cd85d4a7ee1009b",
   "qemu-util": "6f5922561bbb86e3",
   "compilers-osv-java": "14f2183e5cb49482",
-  "compilers-mirage-ocaml-ukvm": "2c35c23771682e9a"
+  "compilers-osv-dynamic": "v0.0",
+  "compilers-mirage-ocaml-ukvm": "2c35c23771682e9a"  
 }

--- a/docs/compilers/osv-mikelangelo.md
+++ b/docs/compilers/osv-mikelangelo.md
@@ -1,0 +1,26 @@
+UniK has a built-in support to directly run application packages provided in
+[MIKELANGELO Project](https://www.mikelangelo-project.eu)'s
+[format](https://github.com/mikelangelo-project/capstan/blob/develop/Documentation/ApplicationManagement.md#package-management).
+
+### Dynamic compiler
+UniK offers a dynamic OSv compiler to run arbitrary Capstan package.
+To use dynamic compiler, you must wrap your binaries into a Capstan package.
+Consult [Capstan documentation](https://github.com/mikelangelo-project/capstan/blob/develop/Documentation/ApplicationManagement.md#package-management)
+to learn how to prepare a valid Capstan package. To sum it up, you need to perform these two steps:
+
+1. compile your code, if needed (e.g. for NodeJS this step is not needed, but for Java it is)
+2. create `meta` folder in your project root, with two files in it (
+[package.yaml](https://github.com/mikelangelo-project/capstan/blob/develop/Documentation/ApplicationManagement.md#manual-initialisation-of-a-package) and
+[run.yaml](https://github.com/mikelangelo-project/capstan/blob/develop/Documentation/ApplicationManagement.md#runyaml-optional)
+)
+
+That's it! Now you can build unikernel with your application using this command:
+```
+$ unik build
+    --name myImage
+    --path ./
+    --base osv
+    --language dynamic # <------ dynamic compiler
+    --provider openstack
+```
+NOTE: Currently, only `openstack` and `qemu` providers are supported by dynamic OSv compiler.

--- a/pkg/compilers/names.go
+++ b/pkg/compilers/names.go
@@ -73,6 +73,9 @@ var (
 	OSV_JAVA_QEMU       = compilerName("osv", "java", "qemu")
 	OSV_JAVA_OPENSTACK  = compilerName("osv", "java", "openstack")
 
+	OSV_DYNAMIC_QEMU      = compilerName("osv", "dynamic", "qemu")
+	OSV_DYNAMIC_OPENSTACK = compilerName("osv", "dynamic", "openstack")
+
 	INCLUDEOS_CPP_QEMU       = compilerName("includeos", "cpp", "qemu")
 	INCLUDEOS_CPP_XEN        = compilerName("includeos", "cpp", "xen")
 	INCLUDEOS_CPP_VIRTUALBOX = compilerName("includeos", "cpp", "virtualbox")
@@ -128,6 +131,9 @@ var compilers = []CompilerType{
 	OSV_JAVA_VSPHERE,
 	OSV_JAVA_QEMU,
 	OSV_JAVA_OPENSTACK,
+
+	OSV_DYNAMIC_QEMU,
+	OSV_DYNAMIC_OPENSTACK,
 
 	INCLUDEOS_CPP_QEMU,
 	INCLUDEOS_CPP_XEN,

--- a/pkg/compilers/osv/osv_dynamic.go
+++ b/pkg/compilers/osv/osv_dynamic.go
@@ -1,0 +1,76 @@
+package osv
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/emc-advanced-dev/pkg/errors"
+	unikos "github.com/emc-advanced-dev/unik/pkg/os"
+	"github.com/emc-advanced-dev/unik/pkg/types"
+	unikutil "github.com/emc-advanced-dev/unik/pkg/util"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+type dynamicProjectConfig struct {
+	// Size is a string representing logical image size e.g. "10GB"
+	Size string `yaml:"image_size"`
+}
+
+// CreateImageDynamic creates OSv image from project source directory and returns filepath of it.
+func CreateImageDynamic(params types.CompileImageParams, useEc2Bootstrap bool) (string, error) {
+	container := unikutil.NewContainer("compilers-osv-dynamic").
+		WithVolume(params.SourcesDir+"/", "/project_directory").
+		WithEnv("MAX_IMAGE_SIZE", readImageSizeFromManifest(params.SourcesDir))
+
+	logrus.WithFields(logrus.Fields{
+		"params": params,
+	}).Debugf("running compilers-osv-dynamic container")
+
+	if err := container.Run(); err != nil {
+		return "", errors.New("failed running compilers-osv-dynamic on "+params.SourcesDir, err)
+	}
+
+	resultFile, err := ioutil.TempFile("", "osv-dynamic.qemu.")
+	if err != nil {
+		return "", errors.New("failed to create tmpfile for result", err)
+	}
+	defer func() {
+		if err != nil && !params.NoCleanup {
+			os.Remove(resultFile.Name())
+		}
+	}()
+
+	if err := os.Rename(filepath.Join(params.SourcesDir, "boot.qcow2"), resultFile.Name()); err != nil {
+		return "", errors.New("failed to rename result file", err)
+	}
+	return resultFile.Name(), nil
+}
+
+// readImageSizeFromManifest parses manifest.yaml and returns image size string, e.g. "10GB"
+// Returns default image size if anything goes wrong
+func readImageSizeFromManifest(projectDir string) string {
+	config := dynamicProjectConfig{
+		Size: OSV_QEMU_DEFAULT_SIZE,
+	}
+	data, err := ioutil.ReadFile(filepath.Join(projectDir, "manifest.yaml"))
+	if err != nil {
+		return OSV_QEMU_DEFAULT_SIZE
+	}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return OSV_QEMU_DEFAULT_SIZE
+	}
+	// append MB unit if only number was passed
+	rNoUnit, _ := regexp.Compile("^[0-9]+$")
+	if match := rNoUnit.FindStringSubmatch(config.Size); len(match) == 1 {
+		config.Size += "MB"
+	}
+	return config.Size
+}
+
+// readImageSizeFromManifestMB parses manifest.yaml and returns image size in MegaBytes
+func readImageSizeFromManifestMB(projectDir string) unikos.MegaBytes {
+	res, _ := unikos.ParseSize(readImageSizeFromManifest(projectDir))
+	return res
+}

--- a/pkg/compilers/osv/osv_qemu.go
+++ b/pkg/compilers/osv/osv_qemu.go
@@ -1,0 +1,31 @@
+package osv
+
+import (
+	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/types"
+)
+
+const OSV_QEMU_DEFAULT_MEMORY = 512
+const OSV_QEMU_DEFAULT_SIZE = "10GB"
+
+type OsvQemuCompiler struct {
+	OSvCompilerBase
+}
+
+func (osvCompiler *OsvQemuCompiler) CompileRawImage(params types.CompileImageParams) (_ *types.RawImage, err error) {
+	resultFile, err := osvCompiler.CreateImage(params, false)
+	if err != nil {
+		return nil, errors.New("failed to compile raw OSv dynamic image", err)
+	}
+	return &types.RawImage{
+		LocalImagePath: resultFile,
+		StageSpec: types.StageSpec{
+			ImageFormat: types.ImageFormat_QCOW2,
+		},
+		RunSpec: types.RunSpec{
+			StorageDriver:         types.StorageDriver_SATA,
+			DefaultInstanceMemory: OSV_QEMU_DEFAULT_MEMORY,
+			MinInstanceDiskMB:     int(readImageSizeFromManifestMB(params.SourcesDir)),
+		},
+	}, nil
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -378,11 +378,20 @@ func NewUnikDaemon(config config.DaemonConfig) (*UnikDaemon, error) {
 	// At the moment OpenStack provider borrows Xen's compiler.
 	_compilers[compilers.OSV_JAVA_OPENSTACK] = osvJavaXenCompiler
 
+	// osv dynamic
 	d := &UnikDaemon{
 		server:    lxmartini.QuietMartini(),
 		providers: _providers,
 		compilers: _compilers,
 	}
+
+	osvDynamicQemuCompiler := &osv.OsvQemuCompiler{
+		OSvCompilerBase: osv.OSvCompilerBase{
+			CreateImage: osv.CreateImageDynamic,
+		},
+	}
+	_compilers[compilers.OSV_DYNAMIC_QEMU] = osvDynamicQemuCompiler
+	_compilers[compilers.OSV_DYNAMIC_OPENSTACK] = osvDynamicQemuCompiler
 
 	d.initialize()
 

--- a/pkg/providers/openstack/run_instance.go
+++ b/pkg/providers/openstack/run_instance.go
@@ -12,8 +12,6 @@ import (
 const DEFAULT_INSTANCE_DISKMB int = 10 * 1024 // 10 GB
 
 func (p *OpenstackProvider) RunInstance(params types.RunInstanceParams) (_ *types.Instance, err error) {
-	// return nil, errors.New("not yet supportded for openstack", nil)
-
 	logrus.WithFields(logrus.Fields{
 		"image-id": params.ImageId,
 		"mounts":   params.MntPointsToVolumeIds,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -134,11 +134,13 @@ const (
 type RunSpec struct {
 	DeviceMappings []DeviceMapping `json:"DeviceMappings"` //required for all compilers
 	// DefaultInstanceMemory is in MB
-	DefaultInstanceMemory int                `json:"DefaultInstanceMemory"` //required for all compilers
-	MinInstanceDiskMB     int                `json:"MinInstanceDiskMB"`
-	StorageDriver         StorageDriver      `json:"StorageDriver,omitempty"`
-	VsphereNetworkType    VsphereNetworkType `json:"VsphereNetworkType"`
-	Compiler              string             `json:"Compiler,omitempty"`
+	DefaultInstanceMemory int `json:"DefaultInstanceMemory"` //required for all compilers
+	// MinInstanceDiskMB specifies minimum disk requirement to run the instance.
+	// Used e.g. to pick flavor in the case of OpenStack provider.
+	MinInstanceDiskMB  int                `json:"MinInstanceDiskMB"`
+	StorageDriver      StorageDriver      `json:"StorageDriver,omitempty"`
+	VsphereNetworkType VsphereNetworkType `json:"VsphereNetworkType"`
+	Compiler           string             `json:"Compiler,omitempty"`
 }
 
 type DeviceMapping struct {


### PR DESCRIPTION
Added dynamic OSV compiler that uses forked Capstan tool
to create OSv unikernels. This Capstan is able to
set arbitrary logical image size during compose (as opposed
to default 10GB). Therefore a --size argument was added
to the 'unik build' command.
# Testing

You can use these three example applications to test the new funcionality:
[dynamic-compiler-examples.zip](https://github.com/emc-advanced-dev/unik/files/542248/dynamic-compiler-examples.zip)
Just navigate to project folder and run `./unik_openstack_up.sh` to create OSv unikernel, upload it to OpenStack and run it.
