### PR TITLE
Refactor OSv compiler

### DIFF
--- a/pkg/compilers/osv/generic.go
+++ b/pkg/compilers/osv/generic.go
@@ -4,6 +4,35 @@ import (
 	"github.com/emc-advanced-dev/unik/pkg/types"
 )
 
+// OSvCompilerBase should be embedded in all OSv compilers.
 type OSvCompilerBase struct {
-	CreateImage func(params types.CompileImageParams, useEc2Bootstrap bool) (string, error)
+	CompilerHelper CompilerHelper
+}
+
+// ConvertParams contains all the information needed when bootstrapping.
+type ConvertParams struct {
+	// CapstanImagePath points to image that was composed by Capstan
+	CapstanImagePath string
+
+	// CompileParams stores parameters that were used for composing image
+	CompileParams types.CompileImageParams
+}
+
+// CompilerHelper implements conversion of Capstan result into provider-specific image.
+// It should be implemented per provider. In this context converting means e.g.
+// converting .qcow2 image (Capstan result) into .wmdk for VirtualBox provider.
+type CompilerHelper interface {
+	// Convert converts Capstan-provided image into appropriate format
+	// for the provider
+	Convert(params ConvertParams) (*types.RawImage, error)
+
+	// UseEc2 tells whether or not to prepare image for EC2 (Elastic Compute Cloud)
+	UseEc2() bool
+}
+
+// CompilerHelperBase should be embedded in every CompilerHelper implementation.
+type CompilerHelperBase struct{}
+
+func (b *CompilerHelperBase) UseEc2() bool {
+	return false
 }

--- a/pkg/compilers/osv/osv_aws.go
+++ b/pkg/compilers/osv/osv_aws.go
@@ -1,23 +1,18 @@
 package osv
 
 import (
-	"github.com/emc-advanced-dev/pkg/errors"
 	"github.com/emc-advanced-dev/unik/pkg/types"
 )
 
-type OsvAwsCompiler struct {
-	OSvCompilerBase
-}
-
 const OSV_AWS_MEMORY = 1024
 
-func (osvCompiler *OsvAwsCompiler) CompileRawImage(params types.CompileImageParams) (_ *types.RawImage, err error) {
-	resultFile, err := osvCompiler.CreateImage(params, true)
-	if err != nil {
-		return nil, errors.New("failed to compile raw osv image", err)
-	}
+type AwsCompilerHelper struct {
+	CompilerHelperBase
+}
+
+func (b *AwsCompilerHelper) Convert(params ConvertParams) (*types.RawImage, error) {
 	return &types.RawImage{
-		LocalImagePath: resultFile,
+		LocalImagePath: params.CapstanImagePath,
 		StageSpec: types.StageSpec{
 			ImageFormat:           types.ImageFormat_QCOW2,
 			XenVirtualizationType: types.XenVirtualizationType_HVM,
@@ -29,4 +24,8 @@ func (osvCompiler *OsvAwsCompiler) CompileRawImage(params types.CompileImagePara
 			DefaultInstanceMemory: OSV_AWS_MEMORY,
 		},
 	}, nil
+}
+
+func (b *AwsCompilerHelper) UseEc2() bool {
+	return true
 }

--- a/pkg/compilers/osv/osv_java.go
+++ b/pkg/compilers/osv/osv_java.go
@@ -1,8 +1,6 @@
 package osv
 
 import (
-	"os"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/emc-advanced-dev/pkg/errors"
 	"github.com/emc-advanced-dev/unik/pkg/types"
@@ -12,6 +10,10 @@ import (
 	"path/filepath"
 )
 
+type OSvJavaCompiler struct {
+	OSvCompilerBase
+}
+
 // javaProjectConfig defines available inputs
 type javaProjectConfig struct {
 	MainFile    string `yaml:"main_file"`
@@ -19,22 +21,21 @@ type javaProjectConfig struct {
 	BuildCmd    string `yaml:"build_command"`
 }
 
-// CreateImageJava creates OSv image from project source code and returns filepath of it.
-func CreateImageJava(params types.CompileImageParams, useEc2Bootstrap bool) (string, error) {
+func (r *OSvJavaCompiler) CompileRawImage(params types.CompileImageParams) (*types.RawImage, error) {
 	sourcesDir := params.SourcesDir
 
 	var config javaProjectConfig
 	data, err := ioutil.ReadFile(filepath.Join(sourcesDir, "manifest.yaml"))
 	if err != nil {
-		return "", errors.New("failed to read manifest.yaml file", err)
+		return nil, errors.New("failed to read manifest.yaml file", err)
 	}
 	if err := yaml.Unmarshal(data, &config); err != nil {
-		return "", errors.New("failed to parse yaml manifest.yaml file", err)
+		return nil, errors.New("failed to parse yaml manifest.yaml file", err)
 	}
 
 	container := unikutil.NewContainer("compilers-osv-java").WithVolume("/dev", "/dev").WithVolume(sourcesDir+"/", "/project_directory")
 	var args []string
-	if useEc2Bootstrap {
+	if r.CompilerHelper.UseEc2() {
 		args = append(args, "-ec2")
 	}
 
@@ -52,21 +53,13 @@ func CreateImageJava(params types.CompileImageParams, useEc2Bootstrap bool) (str
 	}).Debugf("running compilers-osv-java container")
 
 	if err := container.Run(args...); err != nil {
-		return "", errors.New("failed running compilers-osv-java on "+sourcesDir, err)
+		return nil, errors.New("failed running compilers-osv-java on "+sourcesDir, err)
 	}
 
-	resultFile, err := ioutil.TempFile("", "osv-boot.vmdk.")
-	if err != nil {
-		return "", errors.New("failed to create tmpfile for result", err)
+	// And finally bootstrap.
+	convertParams := ConvertParams{
+		CompileParams:    params,
+		CapstanImagePath: filepath.Join(sourcesDir, "boot.qcow2"),
 	}
-	defer func() {
-		if err != nil && !params.NoCleanup {
-			os.Remove(resultFile.Name())
-		}
-	}()
-
-	if err := os.Rename(filepath.Join(sourcesDir, "boot.qcow2"), resultFile.Name()); err != nil {
-		return "", errors.New("failed to rename result file", err)
-	}
-	return resultFile.Name(), nil
+	return r.CompilerHelper.Convert(convertParams)
 }

--- a/pkg/compilers/osv/osv_virtualbox.go
+++ b/pkg/compilers/osv/osv_virtualbox.go
@@ -1,23 +1,18 @@
 package osv
 
 import (
-	"github.com/emc-advanced-dev/pkg/errors"
 	"github.com/emc-advanced-dev/unik/pkg/types"
 )
 
 const OSV_VIRTUALBOX_MEMORY = 512
 
-type OsvVirtualboxCompiler struct {
-	OSvCompilerBase
+type VirtualboxCompilerHelper struct {
+	CompilerHelperBase
 }
 
-func (osvCompiler *OsvVirtualboxCompiler) CompileRawImage(params types.CompileImageParams) (_ *types.RawImage, err error) {
-	resultFile, err := osvCompiler.CreateImage(params, false)
-	if err != nil {
-		return nil, errors.New("failed to compile raw OSv Java image", err)
-	}
+func (b *VirtualboxCompilerHelper) Convert(params ConvertParams) (*types.RawImage, error) {
 	return &types.RawImage{
-		LocalImagePath: resultFile,
+		LocalImagePath: params.CapstanImagePath,
 		StageSpec: types.StageSpec{
 			ImageFormat: types.ImageFormat_QCOW2,
 		},

--- a/pkg/compilers/osv/osv_vmware.go
+++ b/pkg/compilers/osv/osv_vmware.go
@@ -1,23 +1,18 @@
 package osv
 
 import (
-	"github.com/emc-advanced-dev/pkg/errors"
 	"github.com/emc-advanced-dev/unik/pkg/types"
 )
 
-type OsvVmwareCompiler struct {
-	OSvCompilerBase
-}
-
 const OSV_VMWARE_MEMORY = 512
 
-func (osvCompiler *OsvVmwareCompiler) CompileRawImage(params types.CompileImageParams) (_ *types.RawImage, err error) {
-	resultFile, err := osvCompiler.CreateImage(params, false)
-	if err != nil {
-		return nil, errors.New("failed to compile raw osv image", err)
-	}
+type VmwareCompilerHelper struct {
+	CompilerHelperBase
+}
+
+func (b *VmwareCompilerHelper) Convert(params ConvertParams) (*types.RawImage, error) {
 	return &types.RawImage{
-		LocalImagePath: resultFile,
+		LocalImagePath: params.CapstanImagePath,
 		StageSpec: types.StageSpec{
 			ImageFormat: types.ImageFormat_QCOW2,
 		},

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -357,21 +357,21 @@ func NewUnikDaemon(config config.DaemonConfig) (*UnikDaemon, error) {
 	_compilers[compilers.RUMP_C_OPENSTACK] = rump.NewRumpCCompiler("compilers-rump-c-hw", rump.CreateImageQemu)
 
 	//osv java
-	osvJavaXenCompiler := &osv.OsvAwsCompiler{
+	osvJavaXenCompiler := &osv.OSvJavaCompiler{
 		OSvCompilerBase: osv.OSvCompilerBase{
-			CreateImage: osv.CreateImageJava,
+			CompilerHelper: &osv.AwsCompilerHelper{},
 		},
 	}
 	_compilers[compilers.OSV_JAVA_XEN] = osvJavaXenCompiler
 	_compilers[compilers.OSV_JAVA_AWS] = osvJavaXenCompiler
-	_compilers[compilers.OSV_JAVA_VIRTUALBOX] = &osv.OsvVirtualboxCompiler{
+	_compilers[compilers.OSV_JAVA_VIRTUALBOX] = &osv.OSvJavaCompiler{
 		OSvCompilerBase: osv.OSvCompilerBase{
-			CreateImage: osv.CreateImageJava,
+			CompilerHelper: &osv.VirtualboxCompilerHelper{},
 		},
 	}
-	_compilers[compilers.OSV_JAVA_VSPHERE] = &osv.OsvVmwareCompiler{
+	_compilers[compilers.OSV_JAVA_VSPHERE] = &osv.OSvJavaCompiler{
 		OSvCompilerBase: osv.OSvCompilerBase{
-			CreateImage: osv.CreateImageJava,
+			CompilerHelper: &osv.VmwareCompilerHelper{},
 		},
 	}
 	// At the moment OpenStack provider borrows Xen's compiler.


### PR DESCRIPTION
OSv compiler needed some changes to match Rumprun compiler structure better. Prior this change, OSv compiler had a reversed logic compared to Rumprun. Fixed.