### PR TITLE
remove unused import

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"path/filepath"
-	"runtime"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/ioutils"


### PR DESCRIPTION
"runtime" is no longer used, which is causing builds with `make` to fail. This fixes #114.