### PR TITLE
Add "unik describe-compiler" CLI

### DIFF
--- a/cmd/describe-compiler.go
+++ b/cmd/describe-compiler.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/client"
+)
+
+var describeCompilerCmd = &cobra.Command{
+	Use:   "describe-compiler",
+	Short: "Describe compiler usage",
+	Long: `Describes compiler usage.
+You must provide triple base-language-provider to specify what compiler to describe.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := func() error {
+			// Determine host.
+			if err := readClientConfig(); err != nil {
+				return err
+			}
+			if host == "" {
+				host = clientConfig.Host
+			}
+			logrus.WithField("host", host).Info("listing providers")
+
+			// Validate input.
+			if base == "" {
+				return errors.New("--base must be set", nil)
+			}
+			if lang == "" {
+				return errors.New("--language must be set", nil)
+			}
+			if provider == "" {
+				return errors.New("--provider must be set", nil)
+			}
+			logrus.WithFields(logrus.Fields{
+				"base":     base,
+				"lang":     lang,
+				"provider": provider,
+			}).Info("describe compiler")
+
+			// Ask daemon.
+			description, err := client.UnikClient(host).DescribeCompiler(base, lang, provider)
+			if err != nil {
+				return err
+			}
+
+			// Print result to the console.
+			fmt.Println(description)
+
+			return nil
+		}(); err != nil {
+			logrus.Errorf("failed describing compiler: %v", err)
+			os.Exit(-1)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(describeCompilerCmd)
+	describeCompilerCmd.Flags().StringVar(&base, "base", "", "<string,required> name of the unikernel base to use")
+	describeCompilerCmd.Flags().StringVar(&lang, "language", "", "<string,required> language the unikernel source is written in")
+	describeCompilerCmd.Flags().StringVar(&provider, "provider", "", "<string,required> name of the target infrastructure to compile for")
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -60,6 +60,22 @@ func (c *client) AvailableProviders() ([]string, error) {
 	return compilers, nil
 }
 
+func (c *client) DescribeCompiler(base string, lang string, provider string) (string, error) {
+	query := buildQuery(map[string]interface{}{
+		"base":     base,
+		"lang":     lang,
+		"provider": provider,
+	})
+	resp, body, err := lxhttpclient.Get(c.unikIP, "/describe_compiler"+query, nil)
+	if err != nil {
+		return "", errors.New("request failed", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New(fmt.Sprintf("failed with status %v: %s", resp.StatusCode, string(body)), err)
+	}
+	return string(body), nil
+}
+
 func buildQuery(params map[string]interface{}) string {
 	queryArray := []string{}
 	for key, val := range params {

--- a/pkg/compilers/includeos/includeos_qemu.go
+++ b/pkg/compilers/includeos/includeos_qemu.go
@@ -4,6 +4,7 @@ import (
 	goerrors "errors"
 	"github.com/Sirupsen/logrus"
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/compilers"
 	"github.com/emc-advanced-dev/unik/pkg/types"
 	unikutil "github.com/emc-advanced-dev/unik/pkg/util"
 	"os"
@@ -49,4 +50,8 @@ func (i *IncludeosQemuCompiler) findFirstImageFile(directory string) (string, er
 		}
 	}
 	return "", errors.New("no image file found", goerrors.New("end of dir"))
+}
+
+func (r *IncludeosQemuCompiler) Usage() *compilers.CompilerUsage {
+	return nil
 }

--- a/pkg/compilers/includeos/includeos_virtualbox.go
+++ b/pkg/compilers/includeos/includeos_virtualbox.go
@@ -6,10 +6,11 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/compilers"
 	"github.com/emc-advanced-dev/unik/pkg/types"
 	unikutil "github.com/emc-advanced-dev/unik/pkg/util"
-	"github.com/Sirupsen/logrus"
 )
 
 type IncludeosVirtualboxCompiler struct{}
@@ -52,4 +53,8 @@ func (i *IncludeosVirtualboxCompiler) findFirstImageFile(directory string) (stri
 		}
 	}
 	return "", errors.New("no image file found", goerrors.New("end of dir"))
+}
+
+func (r *IncludeosVirtualboxCompiler) Usage() *compilers.CompilerUsage {
+	return nil
 }

--- a/pkg/compilers/interface.go
+++ b/pkg/compilers/interface.go
@@ -1,9 +1,56 @@
 package compilers
 
 import (
+	"fmt"
 	"github.com/emc-advanced-dev/unik/pkg/types"
+	"strings"
 )
 
 type Compiler interface {
 	CompileRawImage(params types.CompileImageParams) (*types.RawImage, error)
+
+	// Usage describes how to prepare project to run it with UniK
+	// The returned text should describe what configuration files to
+	// prepare and how.
+	Usage() *CompilerUsage
+}
+
+type CompilerUsage struct {
+	// PrepareApplication section briefly describes how user should
+	// prepare her application PRIOR composing unikernel with UniK
+	PrepareApplication string
+
+	// ConfigurationFiles lists configuration files needed by UniK.
+	// It is a map filename:content_description.
+	ConfigurationFiles map[string]string
+
+	// Other is arbitrary content that will be printed at the end.
+	Other string
+}
+
+func (c *CompilerUsage) ToString() string {
+	prepApp := strings.TrimSpace(c.PrepareApplication)
+	other := strings.TrimSpace(c.Other)
+
+	configFiles := ""
+	for k := range c.ConfigurationFiles {
+		configFiles += fmt.Sprintf("------ %s ------\n", k)
+		configFiles += strings.TrimSpace(c.ConfigurationFiles[k])
+		configFiles += "\n\n"
+	}
+	configFiles = strings.TrimSpace(configFiles)
+
+	description := fmt.Sprintf(`
+HOW TO PREPARE APPLICATION	
+%s
+
+CONFIGURATION FILES
+%s
+`, prepApp, configFiles)
+
+	if other != "" {
+		description += fmt.Sprintf("\nOTHER\n%s", other)
+	}
+
+	return description
 }

--- a/pkg/compilers/mirage/mirage.go
+++ b/pkg/compilers/mirage/mirage.go
@@ -215,6 +215,10 @@ func (c *MirageCompiler) packageUnikernel(sourcesDir string, disks []string, cle
 	return res, nil
 }
 
+func (r *MirageCompiler) Usage() *compilers.CompilerUsage {
+	return nil
+}
+
 var parseRegEx = regexp.MustCompile(`vdev=(\S+),\s.+?target=@\S+?:(\S+?)@`)
 
 func getUnikernelFile(sourcesDir string) (string, error) {

--- a/pkg/compilers/osv/osv_java.go
+++ b/pkg/compilers/osv/osv_java.go
@@ -3,6 +3,7 @@ package osv
 import (
 	"github.com/Sirupsen/logrus"
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/compilers"
 	"github.com/emc-advanced-dev/unik/pkg/types"
 	unikutil "github.com/emc-advanced-dev/unik/pkg/util"
 	"gopkg.in/yaml.v2"
@@ -62,4 +63,13 @@ func (r *OSvJavaCompiler) CompileRawImage(params types.CompileImageParams) (*typ
 		CapstanImagePath: filepath.Join(sourcesDir, "boot.qcow2"),
 	}
 	return r.ImageFinisher.FinishImage(convertParams)
+}
+
+func (r *OSvJavaCompiler) Usage() *compilers.CompilerUsage {
+	return &compilers.CompilerUsage{
+		PrepareApplication: "Compile your Java application into a fat jar.",
+		ConfigurationFiles: map[string]string{
+			"/manifest.yaml": "main_file: <relative-path-to-your-fat-jar>",
+		},
+	}
 }

--- a/pkg/compilers/rump/rump-c.go
+++ b/pkg/compilers/rump/rump-c.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/compilers"
 	"github.com/emc-advanced-dev/unik/pkg/types"
 	"gopkg.in/yaml.v2"
 )
@@ -42,6 +43,10 @@ func (r *RumpCCompiler) CompileRawImage(params types.CompileImageParams) (*types
 	resultFile := path.Join(sourcesDir, "program.bin")
 
 	return r.CreateImage(resultFile, params.Args, params.MntPoints, nil, params.NoCleanup)
+}
+
+func (r *RumpCCompiler) Usage() *compilers.CompilerUsage {
+	return nil
 }
 
 func NewRumpCCompiler(dockerImage string, createImage func(kernel, args string, mntPoints, bakedEnv []string, noCleanup bool) (*types.RawImage, error)) *RumpCCompiler {

--- a/pkg/compilers/rump/rump-go.go
+++ b/pkg/compilers/rump/rump-go.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/compilers"
 	"github.com/emc-advanced-dev/unik/pkg/types"
 )
 
@@ -54,6 +55,10 @@ func (r *RumpGoCompiler) CompileRawImage(params types.CompileImageParams) (*type
 		return nil, errors.New("creating boot volume from kernel binary", err)
 	}
 	return img, nil
+}
+
+func (r *RumpGoCompiler) Usage() *compilers.CompilerUsage {
+	return nil
 }
 
 type godeps struct {

--- a/pkg/compilers/rump/rump-scripting.go
+++ b/pkg/compilers/rump/rump-scripting.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/emc-advanced-dev/pkg/errors"
+	"github.com/emc-advanced-dev/unik/pkg/compilers"
 	"github.com/emc-advanced-dev/unik/pkg/types"
 	"gopkg.in/yaml.v2"
 )
@@ -76,6 +77,10 @@ func (r *RumpScriptCompiler) CompileRawImage(params types.CompileImageParams) (*
 	}
 
 	return r.CreateImage(resultFile, args, params.MntPoints, append(r.ScriptEnv, fmt.Sprintf("MAIN_FILE=%s", config.MainFile), fmt.Sprintf("BOOTSTRAP_TYPE=%s", r.BootstrapType)), params.NoCleanup)
+}
+
+func (r *RumpScriptCompiler) Usage() *compilers.CompilerUsage {
+	return nil
 }
 
 func NewRumpPythonCompiler(dockerImage string, createImage func(kernel, args string, mntPoints, bakedEnv []string, noCleanup bool) (*types.RawImage, error), bootStrapType string) *RumpScriptCompiler {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1139,6 +1139,47 @@ func (d *UnikDaemon) initialize() {
 			return []string(availableProviders), http.StatusOK, nil
 		})
 	})
+	d.server.Get("/describe_compiler", func(res http.ResponseWriter, req *http.Request) {
+		handle(res, func() (interface{}, int, error) {
+			logrus.Debugf("describing compiler")
+
+			// Find compiler.
+			provider := req.FormValue("provider")
+			if _, ok := d.providers[provider]; !ok {
+				return nil, http.StatusBadRequest, errors.New(provider+" is not a known provider. Available: "+
+					strings.Join(d.providers.Keys(), "|"), nil)
+			}
+			base := req.FormValue("base")
+			if base == "" {
+				return nil, http.StatusBadRequest, errors.New("must provide 'base' parameter", nil)
+			}
+			lang := req.FormValue("lang")
+			if lang == "" {
+				return nil, http.StatusBadRequest, errors.New("must provide 'lang' parameter", nil)
+			}
+			compilerName, err := compilers.ValidateCompiler(base, lang, provider)
+			if err != nil {
+				return nil, http.StatusBadRequest, errors.New("invalid base - lang - provider match", err)
+			}
+			compiler, ok := d.compilers[compilerName]
+			if !ok {
+				return nil, http.StatusBadRequest, errors.New("failed to access compiler", nil)
+			}
+
+			logrus.WithFields(logrus.Fields{
+				"compiler": compiler,
+			}).Infof("describe compiler")
+
+			// Let compiler describe itself.
+			compilerUsage := compiler.Usage()
+			description := "<missing compiler description>"
+			if compilerUsage != nil {
+				description = compilerUsage.ToString()
+			}
+
+			return description, http.StatusOK, nil
+		})
+	})
 }
 
 func streamOutput(outputFunc func() (string, error), w io.Writer) (err error) {


### PR DESCRIPTION
Currently user has to consult README to see how her
application must be configured (e.g. what config files
should look like) in order to run it with UniK.
Not any more! Introduced command:

```
$ unik describe-compiler --base <> --language <> --provider <>

HOW TO PREPARE APPLICATION
Compile your Java application into a fat jar.

CONFIGURATION FILES
------ /manifest.yaml ------
main_file: <relative-path-to-your-fat-jar>
```

that prints usage information to the console.