### PR TITLE
fixed java example links

### DIFF
--- a/docs/compilers/osv.md
+++ b/docs/compilers/osv.md
@@ -26,7 +26,7 @@ Compiling Java on the OSv platform requires the following parameters be met:
   * An optional build command for unpackaged sources (required if the project is not already packaged as a `.jar` or `.war` file).
   * The name of the project artifact
   * An optional list of properties (normally set with the `-Dproperty=value` in java) to pass to the application
-  * See the [example java project](../examples/example_java_project) or the [example java servlet](../examples/example_java_project) for an example.
+  * See the [example java project](../examples/example_osv_java_project) or the [example java servlet](../examples/example_osv_java_project) for an example.
 * Either:
   * Project packaged as a fat `.jar` file or `.war` file *or*
   * Project uses **Gradle** or **Maven** and able to be built as a fat `.jar` or `.war`


### PR DESCRIPTION
Fixed the two java example links in the documentation to point to the correct directory.