### PR TITLE
Enable AWS provider for OSv

### DIFF
--- a/pkg/compilers/names.go
+++ b/pkg/compilers/names.go
@@ -75,9 +75,11 @@ var (
 
 	OSV_NODEJS_QEMU      = compilerName("osv", "nodejs", "qemu")
 	OSV_NODEJS_OPENSTACK = compilerName("osv", "nodejs", "openstack")
+	OSV_NODEJS_AWS       = compilerName("osv", "nodejs", "aws")
 
 	OSV_NATIVE_QEMU      = compilerName("osv", "native", "qemu")
 	OSV_NATIVE_OPENSTACK = compilerName("osv", "native", "openstack")
+	OSV_NATIVE_AWS       = compilerName("osv", "native", "aws")
 
 	INCLUDEOS_CPP_QEMU       = compilerName("includeos", "cpp", "qemu")
 	INCLUDEOS_CPP_XEN        = compilerName("includeos", "cpp", "xen")
@@ -137,9 +139,11 @@ var compilers = []CompilerType{
 
 	OSV_NODEJS_QEMU,
 	OSV_NODEJS_OPENSTACK,
+	OSV_NODEJS_AWS,
 
 	OSV_NATIVE_QEMU,
 	OSV_NATIVE_OPENSTACK,
+	OSV_NATIVE_AWS,
 
 	INCLUDEOS_CPP_QEMU,
 	INCLUDEOS_CPP_XEN,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -377,6 +377,9 @@ func NewUnikDaemon(config config.DaemonConfig) (*UnikDaemon, error) {
 	}
 	_compilers[compilers.OSV_NODEJS_QEMU] = osvNodeQemuCompiler
 	_compilers[compilers.OSV_NODEJS_OPENSTACK] = osvNodeQemuCompiler
+	_compilers[compilers.OSV_NODEJS_AWS] = &osv.OSvNodeCompiler{
+		ImageFinisher: &osv.AwsImageFinisher{},
+	}
 
 	// osv native
 	osvNativeQemuCompiler := &osv.OSvNativeCompiler{
@@ -384,6 +387,9 @@ func NewUnikDaemon(config config.DaemonConfig) (*UnikDaemon, error) {
 	}
 	_compilers[compilers.OSV_NATIVE_QEMU] = osvNativeQemuCompiler
 	_compilers[compilers.OSV_NATIVE_OPENSTACK] = osvNativeQemuCompiler
+	_compilers[compilers.OSV_NATIVE_AWS] = &osv.OSvNativeCompiler{
+		ImageFinisher: &osv.AwsImageFinisher{},
+	}
 
 	d := &UnikDaemon{
 		server:    lxmartini.QuietMartini(),


### PR DESCRIPTION
Amazon AWS was enabled for OSv Java, but not for OSv NodeJS and
OSv Native. I only had to explicitly register AWS for them and
it works without any modifications of compilers.