### PR TITLE
Fix wrong git repository name in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 
 RUN go get -u github.com/jteeuwen/go-bindata/...
 
-RUN mkdir -p $GOPATH/src/github.com/emc-advanced-dev/
-WORKDIR $GOPATH/src/github.com/emc-advanced-dev/unik
+RUN mkdir -p $GOPATH/src/github.com/cf-unik/
+WORKDIR $GOPATH/src/github.com/cf-unik/unik
 
-COPY ./ $GOPATH/src/github.com/emc-advanced-dev/unik
+COPY ./ $GOPATH/src/github.com/cf-unik/unik
 
 CMD make -e TARGET_OS=${TARGET_OS} localbuild && mv ./unik /opt/build/unik


### PR DESCRIPTION
Fix the issue #124 by changing the repository name used in the Dockerfile used for building unik binary from a Docker container.
