### PR TITLE
Fix Python3 source code examples in rump.md

### DIFF
--- a/docs/compilers/rump.md
+++ b/docs/compilers/rump.md
@@ -78,7 +78,7 @@ Compiling Python applications on rumprun requires the following parameters be me
   * the `manifest.yaml` file should contain a single line of text like so:
     ```yaml
     main_file: YOUR_MAIN_FILE.py
-  runtime_args: "optional string of python runtime arguments"
+    runtime_args: "optional string of python runtime arguments"
     ```
     where you replace `YOUR_MAIN_FILE.py` with the relative path to your main file from the root directory of your project.
 


### PR DESCRIPTION
Due to some misaligned indentation in one of the examples, certain code blocks from the Python 3 section were being highlighted incorrectly. This fixes that issue.