### PR TITLE
Fix binary build on SELinux enabled systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ endif
 	@echo Building for platform $(UNAME)
 	docker build -t projectunik/$@ -f Dockerfile .
 	mkdir -p ./_build
-	docker run --rm -v $(shell pwd)/_build:/opt/build -e TARGET_OS=$(TARGET_OS) projectunik/$@
+	docker run --rm -v $(shell pwd)/_build:/opt/build:z -e TARGET_OS=$(TARGET_OS) projectunik/$@
 	#docker rmi -f projectunik/$@
 	@echo "Install finished! UniK binary can be found at $(shell pwd)/_build/unik"
 #----


### PR DESCRIPTION
Hello,

Running `make binary` on a SELinux enabled system (specifically: Fedora) generates the following error:

`mv: cannot create regular file '/opt/build/unik': Permission denied`

This PR adds the `z` option to the volume mount argument to fix this error.   